### PR TITLE
first of 2.2

### DIFF
--- a/Models/Call.ts
+++ b/Models/Call.ts
@@ -17,19 +17,16 @@ const CallModel = new mongoose.Schema({
 		required: true
 	},
 	satisfaction: {
-		type: Number,
-		required: false,
-		//[voted, not interested, interested, not answered, removed]
-		enum: [0, 1, 2, 3, 4]
+		type: String,
+		required: false
 	},
 	comment: {
 		type: String,
 		required: false
 	},
 	status: {
-		type: String,
-		required: true,
-		enum: ['In progress', 'to recall', 'Done', 'deleted']
+		type: Boolean,
+		required: false
 	},
 	start: {
 		type: Date,

--- a/Models/Campaign.ts
+++ b/Models/Campaign.ts
@@ -25,11 +25,6 @@ const CampaignSchema = new mongoose.Schema({
 		type: Date,
 		default: Date.now()
 	},
-	trashUser: {
-		type: [mongoose.Schema.Types.ObjectId],
-		ref: 'Client',
-		required: true
-	},
 	password: {
 		type: String,
 		required: true
@@ -59,6 +54,11 @@ const CampaignSchema = new mongoose.Schema({
 		type: Boolean,
 		require: true,
 		default: true
+	},
+	status: {
+		type: [String],
+		require: true,
+		default: ['à suprimer', 'à rapeler', 'tout bon']
 	}
 });
 

--- a/Models/Client.ts
+++ b/Models/Client.ts
@@ -31,6 +31,10 @@ const ClientSchema = new mongoose.Schema({
 	createdAt: {
 		type: Date,
 		default: Date.now()
+	},
+	delete: {
+		type: Boolean,
+		default: false
 	}
 });
 

--- a/router/admin/campaign/GetCampaign.ts
+++ b/router/admin/campaign/GetCampaign.ts
@@ -33,7 +33,11 @@ export default async function getCampaign(req: Request<any>, res: Response<any>)
 		'active',
 		'callHours',
 		'timeBetweenCall',
-		'numberMaxCall'
+		'numberMaxCall',
+		'script',
+		'callPermited',
+		'nbMaxCallCampaign',
+		'satisfactions'
 	]);
 	if (!campaign) {
 		res.status(404).send({ message: 'no campaign', OK: false });

--- a/router/admin/campaign/setSatisfaction.ts
+++ b/router/admin/campaign/setSatisfaction.ts
@@ -1,0 +1,78 @@
+import { Request, Response } from 'express';
+import { ObjectId } from 'mongodb';
+
+import { Area } from '../../../Models/Area';
+import { Campaign } from '../../../Models/Campaign';
+import { log } from '../../../tools/log';
+
+/**
+ * Set the satisfaction of a campaign
+ *
+ * @example
+ * body:{
+ * 	"adminCode": string,
+ * 	"satisfactions": string[],
+ * 	"area": mongoDBID,
+ * 	"CampaignId": mongoDBID
+ * }
+ *
+ * @throws {400} - Missing parameters
+ * @throws {400} - Invalid satisfaction satisfactions must be a array<string>
+ * @throws {400} - Invalid satisfaction satisfactions must contain "à suprimer"
+ * @throws {401} - Wrong admin code
+ * @throws {401} - Wrong campaign id
+ * @throws {200} - OK
+ */
+export default async function setSatisfaction(req: Request<any>, res: Response<any>) {
+	const ip = req.socket?.remoteAddress?.split(':').pop();
+	if (
+		!req.body ||
+		typeof req.body.adminCode != 'string' ||
+		!Array.isArray(req.body.satisfactions) ||
+		(req.body.CampaignId && !ObjectId.isValid(req.body.CampaignId)) ||
+		!ObjectId.isValid(req.body.area)
+	) {
+		res.status(400).send({ message: 'Missing parameters', OK: false });
+		log(`Missing parameters from ` + ip, 'WARNING', __filename);
+		return;
+	}
+
+	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: req.body.adminCode } });
+	if (!area) {
+		res.status(401).send({ message: 'Wrong admin code', OK: false });
+		log(`Wrong admin code from ${ip}`, 'WARNING', __filename);
+		return;
+	}
+
+	let campaign: InstanceType<typeof Campaign> | null = null;
+
+	if (req.body.CampaignId) {
+		campaign = await Campaign.findOne({ _id: { $eq: req.body.CampaignId }, area: area._id });
+	} else {
+		campaign = await Campaign.findOne({ area: area._id, active: true });
+	}
+	if (!campaign) {
+		res.status(401).send({ message: 'Wrong campaign id', OK: false });
+		log(`Wrong campaign id from ${area.name} (${ip})`, 'WARNING', __filename);
+		return;
+	}
+
+	if (req.body.satisfactions && req.body.satisfactions.some((s: any) => typeof s != 'string')) {
+		res.status(400).send({ message: 'Invalid satisfaction, satisfactions must be a array<string>', OK: false });
+		log(`Invalid satisfaction from ${ip}`, 'WARNING', __filename);
+		return;
+	}
+
+	if (req.body.satisfactions && !req.body.satisfactions.includes('à suprimer')) {
+		res.status(400).send({
+			message: 'Invalid satisfaction, satisfactions must contain "à suprimer"',
+			OK: false
+		});
+		log(`Invalid satisfaction from ${ip}`, 'WARNING', __filename);
+		return;
+	}
+
+	await Campaign.updateOne({ _id: campaign._id }, { status: req.body.satisfactions });
+	res.status(200).send({ message: 'Satisfaction updated', OK: true });
+	log(`Satisfaction updated from ${area.name} (${ip})`, 'INFO', __filename);
+}

--- a/router/admin/client/exportClientCsv.ts
+++ b/router/admin/client/exportClientCsv.ts
@@ -58,8 +58,8 @@ export default async function exportClientCsv(req: Request<any>, res: Response<a
 	const clients = Client.find(selector).cursor();
 	await clients.eachAsync(async client => {
 		const csvData: {
-			statut?: 'En cours' | 'Doit etre rappelé·e' | 'Applé·e' | 'Supprimé·e' | 'Aucune info';
-			resultat?: 'A voté' | 'Pas interessé·e' | 'Interessé·e' | 'Pas de réponse' | 'A retirer' | 'Aucune info';
+			statut?: 'Doit etre rappelé·e' | 'Applé·e';
+			resultat?: string;
 			appeleant?: string;
 			commentaire?: string;
 			nombreAppel?: number;
@@ -67,8 +67,8 @@ export default async function exportClientCsv(req: Request<any>, res: Response<a
 		const lastCall = await Call.findOne({ client: client._id, campaign: campaign?._id }).sort({ start: -1 });
 
 		if (lastCall) {
-			csvData.statut = CleanStatus(lastCall?.status);
-			csvData.resultat = cleanSatisfaction(lastCall?.satisfaction);
+			csvData.statut = lastCall.status ? 'Applé·e' : 'Doit etre rappelé·e';
+			csvData.resultat = lastCall?.satisfaction ?? 'Aucune info';
 			csvData.appeleant =
 				(await Caller.findOne({ client: lastCall.caller, area: area._id }, ['name']))?.name ?? 'Erreur';
 			csvData.commentaire = lastCall?.comment ?? '';

--- a/router/admin/stats/call.ts
+++ b/router/admin/stats/call.ts
@@ -39,14 +39,14 @@ export default async function call(req: Request<any>, res: Response<any>) {
 	}
 
 	let totalCalled = await Call.countDocuments({ campaign: campaign._id });
-	let totalNotRespond = await Call.countDocuments({ campaign: campaign._id, status: 'notRespond' });
+	let totalToRecall = await Call.countDocuments({ campaign: campaign._id, status: true });
 	let totalUser = await Client.countDocuments({ campaign: campaign._id });
 	res.status(200).send({
 		message: 'OK',
 		OK: true,
 		data: {
 			totalCalled,
-			totalNotRespond,
+			totalToRecall,
 			totalUser
 		}
 	});

--- a/router/caller/getPhoneNumber.ts
+++ b/router/caller/getPhoneNumber.ts
@@ -55,15 +55,14 @@ export default async function getPhoneNumber(req: Request<any>, res: Response<an
 		'callPermited',
 		'timeBetweenCall',
 		'nbMaxCallCampaign',
-		'trashUser',
-		'active'
+		'active',
+		'status'
 	]);
 	if (!campaign) {
 		res.status(404).send({ message: 'Campaign not found', OK: false });
 		log(`Campaign not found or not active from: ${phone} (${ip})`, 'WARNING', __filename);
 		return;
 	}
-	console.log(phone, req.body.pinCode, req.body.area, campaign.id);
 	const caller = await Caller.findOne(
 		{
 			phone: phone,
@@ -91,10 +90,10 @@ export default async function getPhoneNumber(req: Request<any>, res: Response<an
 		return;
 	}
 
-	const call = await Call.findOne({ caller: { $eq: caller._id }, status: 'In progress', campaign: campaign.id }, [
-		'Client',
-		'Campaign'
-	]);
+	const call = await Call.findOne(
+		{ caller: { $eq: caller._id }, satisfaction: 'In progress', campaign: { $eq: campaign.id } },
+		['client', 'campaign']
+	);
 	if (call) {
 		call.lastInteraction = new Date();
 		try {
@@ -105,16 +104,19 @@ export default async function getPhoneNumber(req: Request<any>, res: Response<an
 			return;
 		}
 		res.status(200).send({
-			message: 'Already in a call',
+			message: 'Client to call',
 			OK: true,
-			client: await Client.findById(call.client),
-			callHistory: await Call.find({
-				client: call.client,
-				campaign: call.campaign,
-				limit: campaign.nbMaxCallCampaign,
-				sort: { start: -1 }
-			}),
-			script: campaign.script
+			client: call.client,
+			callHistory: await Call.find(
+				{
+					client: { $eq: call.client },
+					campaign: { $eq: campaign.id },
+					satisfaction: { $ne: 'In progress' }
+				},
+				['status', 'satisfaction', 'duration', 'comment', 'start']
+			),
+			script: campaign.script,
+			status: campaign.status
 		});
 		log(`Already in a call from: ${caller.name} (${ip})`, 'INFO', __filename);
 		return;
@@ -134,20 +136,22 @@ export default async function getPhoneNumber(req: Request<any>, res: Response<an
 			{
 				$match: {
 					$and: [
-						{ $or: [{ 'calls.status': 'to recall' }, { calls: { $size: 0 } }] }, // keep only client with status to recall or not called
-						{ campaigns: campaign._id } // only client from the campaign
+						{ campaigns: campaign._id }, // only client from the campaign
+						{ delete: { $ne: true } } // client not deleted
 					]
 				}
 			},
 			{
 				$addFields: {
 					nbCalls: { $size: '$calls' },
-					lastCall: { $ifNull: [{ $arrayElemAt: ['$calls.start', -1] }, null] }
+					lastCall: { $ifNull: [{ $arrayElemAt: ['$calls.start', -1] }, null] },
+					lastStatus: { $ifNull: [{ $arrayElemAt: ['$calls.status', -1] }, null] }
 				}
 			},
 			{
 				$match: {
 					$and: [
+						{ $or: [{ 'lastStatus.status': true }, { calls: { $size: 0 } }] }, // keep only client with status true or not called
 						{ nbCalls: { $lt: campaign.nbMaxCallCampaign } }, // client not called too much
 						{
 							$or: [
@@ -185,7 +189,7 @@ export default async function getPhoneNumber(req: Request<any>, res: Response<an
 		client: client[0]._id,
 		caller: caller._id,
 		campaign: campaign._id,
-		status: 'In progress'
+		satisfaction: 'In progress'
 	});
 
 	try {
@@ -193,6 +197,7 @@ export default async function getPhoneNumber(req: Request<any>, res: Response<an
 	} catch (e) {
 		res.status(500).send({ message: 'Internal error', OK: false });
 		log(`Error while saving call from: ${caller.name} (${ip})`, 'ERROR', __filename);
+		console.error(e);
 		return;
 	}
 
@@ -200,13 +205,16 @@ export default async function getPhoneNumber(req: Request<any>, res: Response<an
 		message: 'Client to call',
 		OK: true,
 		client: client[0],
-		callHistory: await Call.find({
-			client: client[0]._id,
-			campaign: campaign._id,
-			limit: campaign.nbMaxCallCampaign,
-			sort: { start: -1 }
-		}),
-		script: campaign.script
+		callHistory: await Call.findOne(
+			{
+				client: { $eq: client[0]?._id },
+				campaign: { $eq: campaign.id },
+				satisfaction: { $ne: 'In progress' }
+			},
+			['status', 'satisfaction', 'duration', 'comment', 'start']
+		),
+		script: campaign.script,
+		status: campaign.status
 	});
 	log(`Client to call from: ${caller.name} (${ip})`, 'INFO', __filename);
 }

--- a/routes.ts
+++ b/routes.ts
@@ -25,6 +25,7 @@ import listCallerCampaign from './router/admin/campaign/listCallerCampaign';
 import listCampaign from './router/admin/campaign/listCampaign';
 import listClientCampaign from './router/admin/campaign/listClientCampaign';
 import setActive from './router/admin/campaign/setActive';
+import setSatisfaction from './router/admin/campaign/setSatisfaction';
 import addCallerCampaign from './router/admin/client/addCallerCampaign';
 import clientInfo from './router/admin/client/clientInfo';
 import createClient from './router/admin/client/createClient';
@@ -111,6 +112,7 @@ router.post('/admin/campaign/listClientCampaign', listClientCampaign);
 router.post('/admin/campaign/listCampaign', listCampaign);
 router.post('/admin/campaign/getCampaign', getCampaign);
 router.post('/admin/campaign/changeScript', changeScript);
+router.post('/admin/campaign/setSatisfaction', setSatisfaction);
 
 //admin/
 router.post('/admin/changePassword', changePasswordAdmin);


### PR DESCRIPTION
# V2.2: Customizing Responses is Here

This update adds the ability to modify possible responses, which are directly stored in campaigns. They can be modified at any time thanks to the new function `/api/admin/campaign/setSatisfaction` (see [new routes](#new-routes)). Obviously, some routes had to be modified due to changes in the internal data schema (see [updated routes](#updated-routes)). This update requires a database update; follow [database update](#database-update).

# New Routes

## /api/admin/campaign/setSatisfaction

This route allows changing the different possible satisfactions at any time. Note that this change is instantaneous, and clients who end a call (`/api/caller/endCall`) with old satisfactions will be rejected (see [/api/caller/endCall](##/api/caller/endCall)).

```json
body:{
    "name": string,
  	"script": string,
  	"adminCode": string,
  	"password": string,
  	"callHoursStart": number,
  	"callHoursEnd": number,
  	"satisfactions": string[],
  	"area": mongoDBID
 }
```

```ts
* @throws {400}: Missing parameters
 * @throws {400}: Invalid satisfaction satisfactions must be a array<string>
 * @throws {400}: Invalid satisfaction satisfactions must contain "à suprimer"
 * @throws {401}: Wrong admin code
 * @throws {400}: Campaign already exist
 * @throws {200}: Campaign created
 * @throws {500}: Internal error
```

# Updated Routes

## /api/admin/createCampaign

It is now possible to add satisfaction values at creation with the optional parameter: `req.body.satisfactions`. This must be an array of strings containing the value "à suprimer". If this array is not provided, the default values `['à suprimer', 'à rapeler', 'tout bon']` will be set.

Two new errors have also been added:

```ts
 * @throws {400}: Invalid satisfaction satisfactions must be a array<string>
 * @throws {400}: Invalid satisfaction satisfactions must contain "à suprimer"
```

## /admin/campaign/getCampaign

The return value now includes additional information for simplicity. The return now contains `['_id','name','active','callHours','timeBetweenCall','numberMaxCall','script','callPermited','nbMaxCallCampaign','satisfactions']`.

The values: `['numberMaxCall','script','callPermited','nbMaxCallCampaign','satisfactions']` have been added.

## /api/admin/client/exportClientsCsv

The return array has some modified return values:

status: now has the type 'Applé·e' | 'Doit etre rappelé·e'

resultat: now has the type: string | 'Aucune info'. Note that string can be any value from campaign.status, and even past value.

## /api/stats/call

The return property `data.totalNotResond` becomes `data.totalToRecall`. Its form changes slightly; as its name indicates, it only gives the number of people to recall, not all who did not respond, including those not called.

## /api/caller/endCall

The property `req.body.satisfaction` changes type from number to string.

The property `req.body.satisfaction` must be included in the array `campaign.status` eq `campaign.satisfaction`. Note that this array can be updated between `/api/caller/getPhoneNumber` and the end of the call. The request will be rejected.

> **The array of possible values will be in `res.data.satisfaction`.**

Several new errors have also been added:

```ts
 * @throws {500}: Invalid campaign in call
 * @throws {500}: satisfaction is not in campaign
 * @throws {500}: client deleted error
 * @throws {500}: invalid client in call
```

These are internal errors and should not occur ;)

## /api/caller/getPhoneNumber

Here, the call history has been fixed, and the phone number search has been improved.

When requesting a phone number, the value `res.status` provides an array of possible statuses at the end of the call. This array can be updated during the call (see [/api/caller/endCall](##/api/caller/endCall)).

The call history contains these values for previous calls: `['status', 'satisfaction', 'duration', 'comment', 'start']`.

# Database Update

To update your database, you can use the tool [ThePiratePhone-Admin-CLI](https://github.com/ThePiratePhone/ThePiratePhone-Admin-CLI).

You will be able to convert your database from 2.1 to 2.2.

and that's it! Enjoy the new features!