### PR TITLE
Remove area for caller

### DIFF
--- a/Models/Caller.ts
+++ b/Models/Caller.ts
@@ -40,8 +40,7 @@ const CallerSchema = new mongoose.Schema({
 	},
 	area: {
 		type: mongoose.Schema.ObjectId,
-		ref: 'Area',
-		required: true
+		ref: 'Area'
 	}
 });
 

--- a/Models/Caller.ts
+++ b/Models/Caller.ts
@@ -37,10 +37,6 @@ const CallerSchema = new mongoose.Schema({
 	createdAt: {
 		type: Date,
 		default: new Date()
-	},
-	area: {
-		type: mongoose.Schema.ObjectId,
-		ref: 'Area'
 	}
 });
 

--- a/router/admin/caller/addCallerCampaign.ts
+++ b/router/admin/caller/addCallerCampaign.ts
@@ -50,7 +50,10 @@ export default async function addCallerCampaign(req: Request<any>, res: Response
 
 	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
 	if (!password) return;
-	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } }, ['name']);
+	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } }, [
+		'name',
+		'campaignList'
+	]);
 	if (!area) {
 		res.status(401).send({ message: 'Wrong admin code', OK: false });
 		log(`[!${req.body.area}, ${ip}] Wrong admin code`, 'WARNING', __filename);
@@ -59,7 +62,9 @@ export default async function addCallerCampaign(req: Request<any>, res: Response
 
 	req.body.phone = clearPhone(req.body.phone);
 
-	const caller = await Caller.findOne({ phone: { $eq: req.body.phone }, area: area._id }, ['campaigns']);
+	const caller = await Caller.findOne({ phone: { $eq: req.body.phone }, campaigns: { $in: area.campaignList } }, [
+		'campaigns'
+	]);
 	if (!caller) {
 		res.status(404).send({ message: 'Caller not found', OK: false });
 		log(`[${ip}, ${req.body.area}] Caller not found`, 'WARNING', __filename);

--- a/router/admin/caller/callerInfo.ts
+++ b/router/admin/caller/callerInfo.ts
@@ -58,14 +58,18 @@ export default async function callerInfo(req: Request<any>, res: Response<any>) 
 
 	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
 	if (!password) return;
-	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } }, ['name']);
+
+	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } }, [
+		'name',
+		'campaignList'
+	]);
 	if (!area) {
 		res.status(404).send({ message: 'no area found', OK: false });
 		log(`[!${req.body.area}, ${ip}] no area found`, 'WARNING', __filename);
 		return;
 	}
 
-	const caller = await Caller.findOne({ phone: { $eq: phone }, area: { $eq: req.body.area } }, [
+	const caller = await Caller.findOne({ phone: { $eq: phone }, campaigns: { $in: area.campaignList } }, [
 		'_id',
 		'name',
 		'phone'

--- a/router/admin/caller/changeCallerPassword.ts
+++ b/router/admin/caller/changeCallerPassword.ts
@@ -66,7 +66,10 @@ export default async function changeCallerPassword(req: Request<any>, res: Respo
 		log(`[!${req.body.area}, ${ip}] Invalid phone number`, 'WARNING', __filename);
 		return;
 	}
-	const result = await Caller.updateOne({ phone: phone, area: area._id }, { pinCode: req.body.newPassword });
+	const result = await Caller.updateOne(
+		{ phone: phone, campaigns: { $in: area.campaignList } },
+		{ pinCode: req.body.newPassword }
+	);
 	if (result.matchedCount != 1) {
 		res.status(404).send({ message: 'Caller not found or same password', OK: false });
 		log(`[${ip}, ${req.body.area}] Caller not found or same password from admin`, 'WARNING', __filename);

--- a/router/admin/caller/changeName.ts
+++ b/router/admin/caller/changeName.ts
@@ -52,8 +52,8 @@ export default async function ChangeName(req: Request<any>, res: Response<any>) 
 		log(`[!${req.body.area}, ${ip}] Wrong phone number`, `WARNING`, __filename);
 		return;
 	}
-	req.body.newName = req.body.newName.trim();
-	if (req.body.newName == ``) {
+	req.body.newName = sanitizeString(req.body.newName);
+	if (req.body.newName == `` || req.body.newName.length > 50 || req.body.newName.length < 3) {
 		res.status(400).send({ message: `Wrong newName`, OK: false });
 		log(`[!${req.body.area}, ${ip}] Wrong newName`, `WARNING`, __filename);
 		return;
@@ -67,8 +67,6 @@ export default async function ChangeName(req: Request<any>, res: Response<any>) 
 		log(`[!${req.body.area}, ${ip}] Wrong admin code`, `WARNING`, __filename);
 		return;
 	}
-
-	req.body.newName = sanitizeString(req.body.newName);
 
 	const change = await Caller.updateOne(
 		{ phone: phone, campaigns: { $in: area.campaignList } },

--- a/router/admin/caller/changeName.ts
+++ b/router/admin/caller/changeName.ts
@@ -70,7 +70,10 @@ export default async function ChangeName(req: Request<any>, res: Response<any>) 
 
 	req.body.newName = sanitizeString(req.body.newName);
 
-	const change = await Caller.updateOne({ phone: phone, area: { $eq: req.body.area } }, { name: req.body.newName });
+	const change = await Caller.updateOne(
+		{ phone: phone, campaigns: { $in: area.campaignList } },
+		{ name: req.body.newName }
+	);
 	if (change.matchedCount != 1) {
 		res.status(400).send({ message: `Caller not found`, OK: false });
 		log(`[${ip}, ${req.body.area}] Caller not found`, `WARNING`, __filename);

--- a/router/admin/caller/exportCallerCsv.ts
+++ b/router/admin/caller/exportCallerCsv.ts
@@ -51,7 +51,7 @@ export default async function exportCallerCsv(req: Request<any>, res: Response<a
 		log(`[!${req.body.area}, ${ip}] Wrong admin code`, 'WARNING', __filename);
 		return;
 	}
-	let selector: {} = { area: area._id };
+	let selector: {} = {};
 
 	const campaign = await Campaign.findOne({ area: area._id, active: true });
 	if (req.body.curentCamaign) {
@@ -60,7 +60,7 @@ export default async function exportCallerCsv(req: Request<any>, res: Response<a
 			log(`[${ip}, ${req.body.area}] No campaign in progress`, 'WARNING', __filename);
 			return;
 		}
-		selector = { $or: [{ campaigns: campaign._id }, { area: area._id }] };
+		selector = { campaigns: campaign._id };
 	}
 
 	const csvStream = csv.format({ headers: true, delimiter: ';' });

--- a/router/admin/caller/listCaller.ts
+++ b/router/admin/caller/listCaller.ts
@@ -59,7 +59,7 @@ export default async function listCaller(req: Request<any>, res: Response<any>) 
 		log(`[${ip}, ${req.body.area}] No caller found`, 'WARNING', __filename);
 		return;
 	}
-	const callers = await Caller.find({ area: area._id })
+	const callers = await Caller.find({ campaigns: { $in: area.campaignList } })
 		.skip(req.body.skip ? req.body.skip : 0)
 		.limit(req.body.limit ? req.body.limit : 50);
 	if (!callers) {

--- a/router/admin/caller/listCaller.ts
+++ b/router/admin/caller/listCaller.ts
@@ -52,7 +52,7 @@ export default async function listCaller(req: Request<any>, res: Response<any>) 
 		return;
 	}
 
-	const numberOfCallers = await Caller.countDocuments({ area: area.id });
+	const numberOfCallers = await Caller.countDocuments({ campaigns: { $in: area.campaignList } });
 
 	if (numberOfCallers === 0) {
 		res.status(404).send({ message: 'No caller found', OK: false });

--- a/router/admin/caller/newCaller.ts
+++ b/router/admin/caller/newCaller.ts
@@ -4,6 +4,7 @@ import { Area } from '../../../Models/Area';
 import { Caller } from '../../../Models/Caller';
 import { log } from '../../../tools/log';
 import { checkParameters, clearPhone, hashPasword, phoneNumberCheck, sanitizeString } from '../../../tools/utils';
+import { Campaign } from '../../../Models/Campaign';
 
 /**
  * Create a new caller
@@ -78,11 +79,13 @@ export default async function newCaller(req: Request<any>, res: Response<any>) {
 		return;
 	}
 
+	const activeCampaigns = await Campaign.find({ area: area._id, active: true });
+
 	const newCaller = new Caller({
 		name: sanitizeString(req.body.name),
 		phone: phone,
 		pinCode: req.body.pinCode,
-		area: area._id
+		campaigns: activeCampaigns.map(campaign => campaign._id)
 	});
 
 	const result = await newCaller.save();

--- a/router/admin/caller/removeCaller.ts
+++ b/router/admin/caller/removeCaller.ts
@@ -60,7 +60,7 @@ export default async function removeCaller(req: Request<any>, res: Response<any>
 		return;
 	}
 
-	const caller = await Caller.findOne({ phone: phone });
+	const caller = await Caller.findOne({ phone: phone, campaigns: { $in: area.campaignList } });
 	if (!caller) {
 		res.status(400).send({ message: 'Caller not found', OK: false });
 		log(`[${ip}, ${req.body.area}] Caller not found`, 'WARNING', __filename);

--- a/router/admin/caller/searchByName.ts
+++ b/router/admin/caller/searchByName.ts
@@ -59,7 +59,7 @@ export default async function SearchByName(req: Request<any>, res: Response<any>
 	const escapedNameParts = sanitizeString(req.body.name).split(' ').map(escapeRegExp);
 	const regexParts = escapedNameParts.map(part => `(?=.*${part})`).join('');
 	const regex = new RegExp(`^${regexParts}`, 'i');
-	const output = await Caller.find({ name: regex, area: area }).limit(10);
+	const output = await Caller.find({ name: regex, campaigns: { $in: area.campaignList } }).limit(10);
 
 	res.status(200).send({ message: 'OK', OK: true, data: output });
 	log(`[${ip}, ${req.body.area}] Caller searched`, 'INFO', __filename);

--- a/router/admin/caller/searchByPhone.ts
+++ b/router/admin/caller/searchByPhone.ts
@@ -55,7 +55,7 @@ export default async function SearchByPhone(req: Request<any>, res: Response<any
 
 	const output = await Caller.find({
 		phone: { $regex: req.body.phone, $options: 'i' },
-		area: { $eq: req.body.area }
+		campaigns: { $in: area.campaignList }
 	}).limit(10);
 	res.status(200).send({ message: 'OK', OK: true, data: output });
 	log(`[${ip}, ${req.body.area}] caller searched`, 'INFO', __filename);

--- a/router/admin/campaign/listCallerCampaign.ts
+++ b/router/admin/campaign/listCallerCampaign.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from 'express';
-import { ObjectId } from 'mongodb';
 import { Area } from '../../../Models/Area';
 import { Caller } from '../../../Models/Caller';
 import { Campaign } from '../../../Models/Campaign';

--- a/router/admin/campaign/listClientCampaign.ts
+++ b/router/admin/campaign/listClientCampaign.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from 'express';
-import { ObjectId } from 'mongodb';
 
 import { Area } from '../../../Models/Area';
 import { Campaign } from '../../../Models/Campaign';

--- a/router/admin/campaign/setActive.ts
+++ b/router/admin/campaign/setActive.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express';
+
 import { Area } from '../../../Models/Area';
 import { Campaign } from '../../../Models/Campaign';
 import { log } from '../../../tools/log';

--- a/router/admin/client/clientInfo.ts
+++ b/router/admin/client/clientInfo.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from 'express';
-import { ObjectId } from 'mongodb';
 
 import { Area } from '../../../Models/Area';
 import { Call } from '../../../Models/Call';
@@ -107,7 +106,7 @@ export default async function clientInfo(req: Request<any>, res: Response<any>) 
 
 	const calls: Array<any> = [];
 	for (const c of call) {
-		const caller = await Caller.findOne({ _id: c.caller, area: area._id });
+		const caller = await Caller.findOne({ _id: c.caller, campaigns: { $in: area.campaignList } });
 		calls.push({ call: c, caller: caller });
 	}
 

--- a/router/admin/client/createClients.ts
+++ b/router/admin/client/createClients.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from 'express';
-import { ObjectId } from 'mongodb';
 
 import { Area } from '../../../Models/Area';
 import { Campaign } from '../../../Models/Campaign';

--- a/router/admin/stats/call.ts
+++ b/router/admin/stats/call.ts
@@ -1,11 +1,10 @@
 import { Request, Response } from 'express';
-import { ObjectId } from 'mongodb';
 
 import { Area } from '../../../Models/Area';
+import { Call } from '../../../Models/Call';
 import { Campaign } from '../../../Models/Campaign';
 import { Client } from '../../../Models/Client';
 import { log } from '../../../tools/log';
-import { Call } from '../../../Models/Call';
 import { checkParameters, hashPasword } from '../../../tools/utils';
 
 /**

--- a/router/admin/stats/callByDate.ts
+++ b/router/admin/stats/callByDate.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from 'express';
-import { ObjectId } from 'mongodb';
 
 import { Area } from '../../../Models/Area';
 import { Call } from '../../../Models/Call';

--- a/router/caller/changeName.ts
+++ b/router/caller/changeName.ts
@@ -10,8 +10,7 @@ import { checkParameters, checkPinCode, clearPhone, phoneNumberCheck, sanitizeSt
  * body:{
  * 	"phone": string,
  * 	"pinCode": string  {max 4 number},
- * 	"newName": string,
- * 	"area": mongoDBID
+ * 	"newName": string
  * }
  * @throws {400}: missing parameters,
  * @throws {400}: Wrong phone number
@@ -32,8 +31,7 @@ export default async function ChangeName(req: Request<any>, res: Response<any>) 
 			[
 				['phone', 'string'],
 				['pinCode', 'string'],
-				['newName', 'string'],
-				['area', 'ObjectId']
+				['newName', 'string']
 			],
 			__filename
 		)
@@ -58,7 +56,7 @@ export default async function ChangeName(req: Request<any>, res: Response<any>) 
 	req.body.newName = sanitizeString(req.body.newName);
 
 	const change = await Caller.updateOne(
-		{ phone: { $eq: req.body.phone }, pinCode: { $eq: req.body.pinCode }, area: { $eq: req.body.area } },
+		{ phone: { $eq: req.body.phone }, pinCode: { $eq: req.body.pinCode } },
 		{ $set: { name: req.body.newName } }
 	);
 	if (change.matchedCount != 1) {

--- a/router/caller/changePassword.ts
+++ b/router/caller/changePassword.ts
@@ -11,7 +11,6 @@ import { checkParameters, checkPinCode, clearPhone, phoneNumberCheck } from '../
  * 	"phone": string,
  * 	"pinCode": string  {max 4 number},
  * 	"newPin": string {max 4 number}
- * 	"area": mongoDBID
  * }
  * @throws {400}: Missing parameters
  * @throws {400}: Invalid pin code
@@ -33,8 +32,7 @@ export default async function changePassword(req: Request<any>, res: Response<an
 			[
 				['phone', 'string'],
 				['pinCode', 'string'],
-				['newPin', 'string'],
-				['area', 'ObjectId']
+				['newPin', 'string']
 			],
 			__filename
 		)
@@ -48,10 +46,7 @@ export default async function changePassword(req: Request<any>, res: Response<an
 		log(`[!${req.body.phone}, ${ip}] Wrong phone number`, 'WARNING', __filename);
 		return;
 	}
-	const caller = await Caller.findOne(
-		{ phone: phone, pinCode: { $eq: String(req.body.pinCode) }, area: { $eq: req.body.area } },
-		['name']
-	);
+	const caller = await Caller.findOne({ phone: phone, pinCode: { $eq: String(req.body.pinCode) } }, ['name']);
 	if (!caller) {
 		res.status(403).send({ message: 'Invalid credential', OK: false });
 		log(`[!${req.body.phone}, ${ip}] Invalid credential`, 'WARNING', __filename);
@@ -66,7 +61,7 @@ export default async function changePassword(req: Request<any>, res: Response<an
 
 	if (req.body.newPin != req.body.pinCode) {
 		const result = await Caller.updateOne(
-			{ phone: phone, pinCode: { $eq: String(req.body.pinCode) }, area: { $eq: req.body.area } },
+			{ phone: phone, pinCode: { $eq: String(req.body.pinCode) } },
 			{ pinCode: req.body.newPin }
 		);
 

--- a/router/caller/createCaller.ts
+++ b/router/caller/createCaller.ts
@@ -11,15 +11,12 @@ import { checkParameters, checkPinCode, clearPhone, phoneNumberCheck } from '../
  * body:{
  * 	"phone": string,
  * 	"pinCode": string  {max 4 number},
- * 	"area": mongoDBID,
- * 	"AreaPassword": string
  * 	"CallerName": string
  * }
  * @throws {400}: missing parameters,
  * @throws {400}: pin code are more of 4 char,
  * @throws {400}: Wrong phone number
  * @throws {400}: Invalid pin code, pin code isn't only number
- * @throws {404}: area not found or invalid password
  * @throws {409}: caller already exist
  * @throws {500}: Error while saving caller
  * @throws {200}: all fine
@@ -36,8 +33,6 @@ export default async function createCaller(req: Request<any>, res: Response<any>
 			[
 				['phone', 'string'],
 				['pinCode', 'string'],
-				['area', 'ObjectId'],
-				['AreaPassword', 'string'],
 				['CallerName', 'string']
 			],
 			__filename
@@ -56,25 +51,15 @@ export default async function createCaller(req: Request<any>, res: Response<any>
 		return;
 	}
 
-	const area = await Area.findOne({ _id: { $eq: req.body.area }, password: { $eq: req.body.AreaPassword } }, [
-		'name'
-	]);
-	if (!area) {
-		res.status(404).send({ message: 'area not found or invalid password', OK: false });
-		log(`[!${req.body.phone}, ${ip}] area not found or invalid password`, 'WARNING', __filename);
-		return;
-	}
-
 	if ((await Caller.countDocuments({ phone: phone })) != 0) {
 		res.status(409).send({ message: 'caller already exist', OK: false });
-		log(`[${req.body.phone}, ${ip}] caller already exist in ${area.name}`, 'WARNING', 'createCaller.ts');
+		log(`[${req.body.phone}, ${ip}] caller already exist`, 'WARNING', 'createCaller.ts');
 		return;
 	}
 
 	const newCaller = new Caller({
 		phone: phone,
 		pinCode: req.body.pinCode,
-		area: area._id,
 		name: req.body.CallerName
 	});
 

--- a/router/caller/createCaller.ts
+++ b/router/caller/createCaller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 
-import { Area } from '../../Models/Area';
 import { Caller } from '../../Models/Caller';
+import { Campaign } from '../../Models/Campaign';
 import { log } from '../../tools/log';
 import { checkParameters, checkPinCode, clearPhone, phoneNumberCheck } from '../../tools/utils';
 
@@ -11,11 +11,12 @@ import { checkParameters, checkPinCode, clearPhone, phoneNumberCheck } from '../
  * body:{
  * 	"phone": string,
  * 	"pinCode": string  {max 4 number},
- * 	"CallerName": string
+ * 	"CallerName": string,
+ * 	"campaignPassword": string
  * }
  * @throws {400}: missing parameters,
- * @throws {400}: pin code are more of 4 char,
  * @throws {400}: Wrong phone number
+ * @throws {400}: Invalid campaign password, campaign not found or disabled
  * @throws {400}: Invalid pin code, pin code isn't only number
  * @throws {409}: caller already exist
  * @throws {500}: Error while saving caller
@@ -33,7 +34,8 @@ export default async function createCaller(req: Request<any>, res: Response<any>
 			[
 				['phone', 'string'],
 				['pinCode', 'string'],
-				['CallerName', 'string']
+				['CallerName', 'string'],
+				['campaignPassword', 'string']
 			],
 			__filename
 		)
@@ -51,6 +53,17 @@ export default async function createCaller(req: Request<any>, res: Response<any>
 		return;
 	}
 
+	const campaign = await Campaign.findOne({
+		password: { $eq: req.body.campaignPassword },
+		active: true
+	});
+
+	if (!campaign) {
+		res.status(400).send({ message: 'Invalid campaign password', OK: false });
+		log(`[${req.body.phone}, ${ip}] Invalid campaign password`, 'WARNING', 'createCaller.ts');
+		return;
+	}
+
 	if ((await Caller.countDocuments({ phone: phone })) != 0) {
 		res.status(409).send({ message: 'caller already exist', OK: false });
 		log(`[${req.body.phone}, ${ip}] caller already exist`, 'WARNING', 'createCaller.ts');
@@ -60,7 +73,8 @@ export default async function createCaller(req: Request<any>, res: Response<any>
 	const newCaller = new Caller({
 		phone: phone,
 		pinCode: req.body.pinCode,
-		name: req.body.CallerName
+		name: req.body.CallerName,
+		campaigns: [campaign._id]
 	});
 
 	const result = await newCaller.save();
@@ -70,6 +84,6 @@ export default async function createCaller(req: Request<any>, res: Response<any>
 		return;
 	}
 
-	res.status(200).send({ message: 'Caller created', OK: true });
+	res.status(200).send({ message: 'Caller created', data: { campaign }, OK: true });
 	log(`[${req.body.phone}, ${ip}] Caller ${newCaller.name} created`, 'INFO', 'createCaller.ts');
 }

--- a/router/caller/endCall.ts
+++ b/router/caller/endCall.ts
@@ -16,9 +16,7 @@ import { checkParameters, checkPinCode, clearPhone, phoneNumberCheck, sanitizeSt
  * 	"timeInCall": number,
  * 	"satisfaction": number {-1, 0, 1, 2, 3, 4},
  * 	"comment": string | null,
- * 	"status": Boolean,
- *
- * 	"area": mongoDBID
+ * 	"status": Boolean
  * }
  *
  * @throws {400}: Missing parameters
@@ -48,7 +46,6 @@ export default async function endCall(req: Request<any>, res: Response<any>) {
 				['timeInCall', 'number'],
 				['satisfaction', 'string'],
 				['status', 'boolean'],
-				['area', 'ObjectId'],
 				['comment', 'string', true]
 			],
 			__filename
@@ -67,10 +64,7 @@ export default async function endCall(req: Request<any>, res: Response<any>) {
 
 	req.body.timeInCall = Math.min(req.body.timeInCall, 1_200_000);
 
-	const caller = await Caller.findOne(
-		{ phone: phone, pinCode: { $eq: req.body.pinCode }, area: { $eq: req.body.area } },
-		['name']
-	);
+	const caller = await Caller.findOne({ phone: phone, pinCode: { $eq: req.body.pinCode } }, ['name']);
 	if (!caller) {
 		res.status(403).send({ message: 'Invalid credential', OK: false });
 		log(`[!${req.body.phone}, ${ip}] Invalid credential`, 'WARNING', __filename);

--- a/router/caller/getPhoneNumber.ts
+++ b/router/caller/getPhoneNumber.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import mongoose from 'mongoose';
+import mongoose, { Types } from 'mongoose';
 
 import { Area } from '../../Models/Area';
 import { Call } from '../../Models/Call';
@@ -15,7 +15,6 @@ import { checkParameters, checkPinCode, clearPhone, phoneNumberCheck } from '../
  * body:{
  * 	"phone": string,
  * 	"pinCode": string  {max 4 number},
- * 	"area":mongoDBID,
  * 	"campaign": mongoDBID
  * }
  *
@@ -43,8 +42,7 @@ export default async function getPhoneNumber(req: Request<any>, res: Response<an
 			[
 				['phone', 'string'],
 				['pinCode', 'string'],
-				['area', 'ObjectId'],
-				['campaign', 'ObjectId', true]
+				['campaign', 'ObjectId']
 			],
 			__filename
 		)
@@ -59,56 +57,30 @@ export default async function getPhoneNumber(req: Request<any>, res: Response<an
 		return;
 	}
 
-	const area = await Area.findOne({ _id: { $eq: req.body.area } });
-	if (!area) {
-		res.status(404).send({ message: 'Area not found', OK: false });
-		log(`[!${req.body.phone}, ${ip}] Area not found from (${ip})`, 'WARNING', __filename);
-		return;
-	}
-
-	let campaign: InstanceType<typeof Campaign> | null = null;
-	if (req.body.CampaignId) {
-		campaign = await Campaign.findOne(
-			{
-				_id: { $eq: req.body.CampaignId },
-				area: area._id,
-				password: { $eq: req.body.campaignPassword }
-			},
-			['script', 'callPermited', 'timeBetweenCall', 'nbMaxCallCampaign', 'active', 'status']
-		);
-	} else {
-		campaign = await Campaign.findOne(
-			{
-				area: area._id,
-				active: true
-			},
-			['script', 'callPermited', 'timeBetweenCall', 'nbMaxCallCampaign', 'active', 'status']
-		);
-	}
-
-	if (!campaign || !campaign.active) {
-		res.status(404).send({ message: 'Campaign not found or not active', OK: false });
-		log(`[!${req.body.phone}, ${ip}] Campaign not found or not active`, 'WARNING', __filename);
-		return;
-	}
 	const caller = await Caller.findOne(
 		{
 			phone: phone,
 			pinCode: { $eq: req.body.pinCode },
-			$or: [
-				{
-					campaigns: campaign.id
-				},
-				{
-					area: { $eq: req.body.area }
-				}
-			]
+			campaigns: { $in: [new Types.ObjectId(req.body.campaign)] }
 		},
 		['name']
 	);
 	if (!caller) {
 		res.status(403).send({ message: 'Invalid credential or incorrect campaing', OK: false });
 		log(`[!${req.body.phone}, ${ip}] Invalid credential or incorrect campaing`, 'WARNING', __filename);
+		return;
+	}
+
+	let campaign = await Campaign.findOne(
+		{
+			_id: { $eq: req.body.campaign }
+		},
+		['script', 'callPermited', 'timeBetweenCall', 'nbMaxCallCampaign', 'active', 'status']
+	);
+
+	if (!campaign || !campaign.active) {
+		res.status(404).send({ message: 'Campaign not found or not active', OK: false });
+		log(`[!${req.body.phone}, ${ip}] Campaign not found or not active`, 'WARNING', __filename);
 		return;
 	}
 
@@ -167,7 +139,7 @@ export default async function getPhoneNumber(req: Request<any>, res: Response<an
 						$filter: {
 							input: '$calls',
 							as: 'call',
-							cond: { $eq: ['$$call.campaign', campaign._id] } // Ne garder que les appels de la campagne actuelle
+							cond: { $eq: ['$$call.campaign', campaign._id] } // Keep only calls from the current campaign
 						}
 					}
 				}
@@ -200,15 +172,15 @@ export default async function getPhoneNumber(req: Request<any>, res: Response<an
 			{
 				$match: {
 					$and: [
-						{ campaigns: { $in: [campaign._id] } }, // Filtrer uniquement les clients de la campagne
-						{ delete: { $ne: true } }, // Exclure les clients supprimés
-						{ lastSatisfaction: { $ne: 'In progress' } }, // Exclure les clients en appel
-						{ $or: [{ lastStatus: true }, { nbCalls: 0 }] }, // Garder les clients valides ou jamais appelés
-						{ nbCalls: { $lt: campaign.nbMaxCallCampaign } }, // Ne pas dépasser le nombre max d'appels
+						{ campaigns: { $in: [campaign._id] } }, // Filter only clients from the campaign
+						{ delete: { $ne: true } }, // Exclude deleted clients
+						{ lastSatisfaction: { $ne: 'In progress' } }, // Exclude clients currently in a call
+						{ $or: [{ lastStatus: true }, { nbCalls: 0 }] }, // Keep valid clients or those never called
+						{ nbCalls: { $lt: campaign.nbMaxCallCampaign } }, // Do not exceed the maximum number of calls
 						{
 							$or: [
-								{ lastCall: { $lte: new Date(Date.now() - campaign.timeBetweenCall) } }, // Respecter le temps minimum entre les appels
-								{ lastCall: null } // Inclure ceux qui n'ont jamais été appelés
+								{ lastCall: { $lte: new Date(Date.now() - campaign.timeBetweenCall) } }, // Respect the minimum time between calls
+								{ lastCall: null } // Include those who have never been called
 							]
 						}
 					]

--- a/router/caller/getPhoneNumber.ts
+++ b/router/caller/getPhoneNumber.ts
@@ -73,12 +73,13 @@ export default async function getPhoneNumber(req: Request<any>, res: Response<an
 
 	let campaign = await Campaign.findOne(
 		{
-			_id: { $eq: req.body.campaign }
+			_id: { $eq: req.body.campaign },
+			active: true
 		},
 		['script', 'callPermited', 'timeBetweenCall', 'nbMaxCallCampaign', 'active', 'status']
 	);
 
-	if (!campaign || !campaign.active) {
+	if (!campaign) {
 		res.status(404).send({ message: 'Campaign not found or not active', OK: false });
 		log(`[!${req.body.phone}, ${ip}] Campaign not found or not active`, 'WARNING', __filename);
 		return;

--- a/router/caller/giveUp.ts
+++ b/router/caller/giveUp.ts
@@ -13,7 +13,6 @@ import { checkParameters, checkPinCode, clearPhone, phoneNumberCheck } from '../
  * {
  * 	"phone": string,
  * 	"pinCode": string  {max 4 number}
- * 	"area": mongoDBID
  * }
  *
  * @throws {400}: Missing parameters
@@ -34,8 +33,7 @@ export default async function giveUp(req: Request<any>, res: Response<any>) {
 			res,
 			[
 				['phone', 'string'],
-				['pinCode', 'string'],
-				['area', 'ObjectId']
+				['pinCode', 'string']
 			],
 			__filename
 		)
@@ -51,13 +49,10 @@ export default async function giveUp(req: Request<any>, res: Response<any>) {
 		return;
 	}
 
-	const caller = await Caller.findOne(
-		{ phone: phone, pinCode: { $eq: req.body.pinCode }, area: { $eq: req.body.area } },
-		['name', 'phone']
-	);
+	const caller = await Caller.findOne({ phone: phone, pinCode: { $eq: req.body.pinCode } }, ['name', 'phone']);
 	if (!caller) {
-		res.status(403).send({ message: 'Invalid credential or incorrect area', OK: false });
-		log(`[!${req.body.phone}, ${ip}] Invalid credential or incorrect area`, 'WARNING', 'giveUp.ts');
+		res.status(403).send({ message: 'Invalid credential', OK: false });
+		log(`[!${req.body.phone}, ${ip}] Invalid credential`, 'WARNING', 'giveUp.ts');
 		return;
 	}
 

--- a/router/caller/joinCampaign.ts
+++ b/router/caller/joinCampaign.ts
@@ -13,7 +13,6 @@ import { checkParameters, checkPinCode, clearPhone, phoneNumberCheck } from '../
  * {
  * 	"phone": string,
  * 	"pinCode": string  {max 4 number},
- * 	"campaignId": mongoDBID,
  * 	"campaignPassword": string
  * }
  *
@@ -37,7 +36,6 @@ export default async function joinCampaign(req: Request<any>, res: Response<any>
 			[
 				['phone', 'string'],
 				['pinCode', 'string'],
-				['campaignId', 'ObjectId'],
 				['campaignPassword', 'string']
 			],
 			__filename
@@ -65,13 +63,9 @@ export default async function joinCampaign(req: Request<any>, res: Response<any>
 		return;
 	}
 
-	const campaign = await Campaign.findOne(
-		{
-			_id: { $eq: req.body.campaignId },
-			password: { $eq: req.body.campaignPassword }
-		},
-		'name'
-	);
+	const campaign = await Campaign.findOne({
+		password: { $eq: req.body.campaignPassword }
+	});
 	if (!campaign) {
 		res.status(404).send({ message: 'new campaign not found', OK: false });
 		log(`[${req.body.phone}, ${ip}] new campaign not found from`, 'WARNING', __filename);
@@ -94,10 +88,7 @@ export default async function joinCampaign(req: Request<any>, res: Response<any>
 
 	res.status(200).send({
 		message: 'Campaign joined',
-		data: {
-			campaignId: campaign._id,
-			campaignName: campaign.name
-		},
+		data: { campaign },
 		OK: true
 	});
 	log(`[${req.body.phone}, ${ip}] join campaign: ${campaign.name}`, 'INFO', __filename);

--- a/router/caller/joinCampaign.ts
+++ b/router/caller/joinCampaign.ts
@@ -13,7 +13,7 @@ import { checkParameters, checkPinCode, clearPhone, phoneNumberCheck } from '../
  * {
  * 	"phone": string,
  * 	"pinCode": string  {max 4 number},
- * 	"campaignId": string,
+ * 	"campaignId": mongoDBID,
  * 	"campaignPassword": string
  * }
  *

--- a/router/caller/joinCampaign.ts
+++ b/router/caller/joinCampaign.ts
@@ -57,8 +57,7 @@ export default async function joinCampaign(req: Request<any>, res: Response<any>
 	const caller = await Caller.findOne({ phone: phone, pinCode: { $eq: req.body.pinCode } }, [
 		'name',
 		'campaigns',
-		'phone',
-		'areasJoined'
+		'phone'
 	]);
 	if (!caller) {
 		res.status(403).send({ message: 'Invalid credential or incorrect campaing', OK: false });
@@ -85,7 +84,7 @@ export default async function joinCampaign(req: Request<any>, res: Response<any>
 	}
 
 	try {
-		caller.areasJoined.push(campaign.id);
+		caller.campaigns.push(campaign.id);
 		await caller.save();
 	} catch (e) {
 		res.status(500).send({ message: 'Internal error', OK: false });

--- a/router/caller/login.ts
+++ b/router/caller/login.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from 'express';
 import { Types } from 'mongoose';
 
-import { Area } from '../../Models/Area';
 import { Caller } from '../../Models/Caller';
 import { Campaign } from '../../Models/Campaign';
 import { log } from '../../tools/log';
@@ -13,7 +12,6 @@ import { checkParameters, checkPinCode, clearPhone, phoneNumberCheck } from '../
  * body:{
  * 	"phone": string,
  * 	"pinCode": string  {max 4 number}
- *	"area": mongoDBID
  * }
  *
  * @throws {400}: Missing parameters

--- a/router/caller/login.ts
+++ b/router/caller/login.ts
@@ -62,7 +62,6 @@ export default async function login(req: Request<any>, res: Response<any>) {
 	}
 	const caller = await Caller.findOne({ phone: phone, pinCode: { $eq: req.body.pinCode } }, [
 		'name',
-		'area',
 		'campaigns',
 		'phone'
 	]);
@@ -71,65 +70,62 @@ export default async function login(req: Request<any>, res: Response<any>) {
 		log(`[!${req.body.phone}, ${ip}] Invalid credential`, 'WARNING', __filename);
 		return;
 	}
-	const area = await Area.findOne({ _id: caller.area });
-	if (!area) {
-		res.status(500).send({ message: 'No area', OK: false });
-		log(`[${req.body.phone}, ${ip}] No area for this user`, 'ERROR', __filename);
-		return;
-	}
-	let areaCombo: {
-		area: { name: string; _id: Types.ObjectId };
-		campaignAvailable: {
-			name: string;
-			callHoursEnd: Date | null | undefined;
-			callHoursStart: Date | null | undefined;
-			_id: Types.ObjectId;
-			areaId: Types.ObjectId;
-			areaName: string;
-			status: Array<{ name?: string | null | undefined; toRecall?: boolean | null | undefined }>;
-		}[];
-	};
-	try {
-		const campaign = await Campaign.find(
-			{
-				$or: [
-					//FIXME use campaign list
-					{ area: { $in: caller.campaigns } },
-					{
-						area: caller.area
-					}
-				],
-				active: true
-			},
-			['name', 'callHoursStart', 'callHoursEnd', 'area', 'status']
-		);
+	let campaignAvailable: {
+		name: string;
+		callHoursEnd: Date | null | undefined;
+		callHoursStart: Date | null | undefined;
+		_id: Types.ObjectId;
+		areaId: Types.ObjectId;
+		areaName: string;
+		status: Array<{ name?: string | null | undefined; toRecall?: boolean | null | undefined }>;
+	}[];
 
-		areaCombo = {
-			area: { name: area.name, _id: area._id },
-			campaignAvailable: await Promise.all(
-				campaign.map(async c => {
-					const cArea = await Area.findById(c.area);
-					if (!cArea) {
-						throw 'error';
-					}
-					return {
-						name: c.name,
-						_id: c._id,
-						callHoursStart: c.callHoursStart,
-						callHoursEnd: c.callHoursEnd,
-						areaId: cArea?._id,
-						areaName: cArea?.name,
-						status: c.status
-					};
-				})
-			)
-		};
+	try {
+		campaignAvailable = await Campaign.aggregate([
+			{
+				$match: {
+					_id: { $in: caller.campaigns },
+					active: true
+				}
+			},
+			{
+				$lookup: {
+					from: 'areas',
+					localField: 'area',
+					foreignField: '_id',
+					as: 'areaDetails'
+				}
+			},
+			{
+				$unwind: '$areaDetails'
+			},
+			{
+				$project: {
+					name: 1,
+					callHoursStart: 1,
+					callHoursEnd: 1,
+					status: 1,
+					areaId: '$areaDetails._id',
+					areaName: '$areaDetails.name'
+				}
+			}
+		]);
+		if (
+			!campaignAvailable ||
+			campaignAvailable.length === 0 ||
+			!campaignAvailable.every(c => c.areaId != undefined && c.areaId != null)
+		) {
+			res.status(500).send({ message: 'area of campaign not found', OK: false });
+			log(`[${req.body.phone}, ${ip}] area of campaign not found`, 'WARNING', __filename);
+			return;
+		}
 	} catch (error) {
 		res.status(500).send({ message: 'area of campaign not found', OK: false });
 		log(`[${req.body.phone}, ${ip}] area of campaign not found`, 'ERROR', __filename);
 		return;
 	}
-	res.status(200).send({ message: 'OK', OK: true, data: { caller: caller, areaCombo: areaCombo } });
+
+	res.status(200).send({ message: 'OK', OK: true, data: { caller: caller, campaignAvailable } });
 	log(`[${req.body.phone}, ${ip}] Login success`, 'INFO', __filename);
 	return;
 }

--- a/router/otherCaller/scoreBoard.ts
+++ b/router/otherCaller/scoreBoard.ts
@@ -54,7 +54,7 @@ export default async function scoreBoard(req: Request<any>, res: Response<any>) 
 	const caller = await Caller.findOne({
 		phone: phone,
 		pinCode: { $eq: req.body.pinCode },
-		campaigns: req.body.campaign
+		campaigns: { $eq: req.body.campaign }
 	});
 	if (!caller) {
 		res.status(404).send({ message: 'Caller not found', OK: false });

--- a/router/otherCaller/scoreBoard.ts
+++ b/router/otherCaller/scoreBoard.ts
@@ -1,10 +1,8 @@
 import { Request, Response } from 'express';
-import { ObjectId } from 'mongodb';
 import mongoose from 'mongoose';
 
 import { Call } from '../../Models/Call';
 import { Caller } from '../../Models/Caller';
-import { Campaign } from '../../Models/Campaign';
 import { log } from '../../tools/log';
 import { checkParameters, clearPhone, phoneNumberCheck } from '../../tools/utils';
 
@@ -21,7 +19,7 @@ import { checkParameters, clearPhone, phoneNumberCheck } from '../../tools/utils
  *
  * @throws {400}: Missing parameters
  * @throws {400}: Wrong phone number
- * @throws {404}: no campaing in progress
+ * @throws {404}: no campaign in progress
  * @throws {404}: Caller not found
  * @throws {500}: No data found
  * @throws {200}: topfiveUsers
@@ -40,7 +38,7 @@ export default async function scoreBoard(req: Request<any>, res: Response<any>) 
 			[
 				['phone', 'string'],
 				['pinCode', 'string'],
-				['campaignId', 'ObjectId']
+				['campaign', 'ObjectId']
 			],
 			__filename
 		)
@@ -56,7 +54,7 @@ export default async function scoreBoard(req: Request<any>, res: Response<any>) 
 	const caller = await Caller.findOne({
 		phone: phone,
 		pinCode: { $eq: req.body.pinCode },
-		campaigns: req.body.campaignId
+		campaigns: req.body.campaign
 	});
 	if (!caller) {
 		res.status(404).send({ message: 'Caller not found', OK: false });
@@ -72,7 +70,7 @@ export default async function scoreBoard(req: Request<any>, res: Response<any>) 
 	}> = await Call.aggregate([
 		{
 			$match: {
-				campaign: mongoose.Types.ObjectId.createFromHexString(req.body.campaignId)
+				campaign: mongoose.Types.ObjectId.createFromHexString(req.body.campaign)
 			}
 		},
 		{
@@ -116,7 +114,7 @@ export default async function scoreBoard(req: Request<any>, res: Response<any>) 
 			await Call.aggregate([
 				{
 					$match: {
-						campaign: mongoose.Types.ObjectId.createFromHexString(req.body.campaignId)
+						campaign: mongoose.Types.ObjectId.createFromHexString(req.body.campaign)
 					}
 				},
 				{

--- a/router/otherCaller/scoreBoard.ts
+++ b/router/otherCaller/scoreBoard.ts
@@ -6,7 +6,7 @@ import { Call } from '../../Models/Call';
 import { Caller } from '../../Models/Caller';
 import { Campaign } from '../../Models/Campaign';
 import { log } from '../../tools/log';
-import { clearPhone, phoneNumberCheck } from '../../tools/utils';
+import { checkParameters, clearPhone, phoneNumberCheck } from '../../tools/utils';
 
 /**
  * get the top 5 callers in a campaign and our score
@@ -15,9 +15,8 @@ import { clearPhone, phoneNumberCheck } from '../../tools/utils';
  * body:
  * {
  * 	"phone": string,
- * 	"pinCode": string  {max 4 number},
- * 	"area": mongoDBID,
- * 	"campaignId": mongoDBID | null
+ * 	"pinCode": string  {max 4 number}
+ * 	"campaignId": mongoDBID
  * }
  *
  * @throws {400}: Missing parameters
@@ -33,28 +32,20 @@ export default async function scoreBoard(req: Request<any>, res: Response<any>) 
 		(Array.isArray(req.headers['x-forwarded-for'])
 			? req.headers['x-forwarded-for'][0]
 			: req.headers['x-forwarded-for']?.split(',')?.[0] ?? req.ip) ?? 'no IP';
-	if (
-		!req.body ||
-		typeof req.body.phone != 'string' ||
-		typeof req.body.pinCode != 'string' ||
-		!ObjectId.isValid(req.body.area) ||
-		(req.body.campaignId && !ObjectId.isValid(req.body.campaignId))
-	) {
-		res.status(400).send({ message: 'Missing parameters', OK: false });
-		log(`[!${req.body.phone}, ${ip}] Missing parameters`, 'WARNING', __filename);
-		return;
-	}
 
-	if (!req.body.campaignId || !ObjectId.isValid(req.body.campaignId)) {
-		req.body.campaignId = (
-			await Campaign.findOne({ area: { $eq: req.body.area }, active: true }, [])
-		)?._id.toString();
-		if (!req.body.campaignId || !ObjectId.isValid(req.body.campaignId)) {
-			res.status(404).send({ message: 'no campaing in progress', OK: false });
-			log(`[!${req.body.phone}, ${ip}] no campaing in progress`, 'WARNING', __filename);
-			return;
-		}
-	}
+	if (
+		!checkParameters(
+			req.body,
+			res,
+			[
+				['phone', 'string'],
+				['pinCode', 'string'],
+				['campaignId', 'ObjectId']
+			],
+			__filename
+		)
+	)
+		return;
 
 	const phone = clearPhone(req.body.phone);
 	if (!phoneNumberCheck(phone)) {
@@ -65,14 +56,7 @@ export default async function scoreBoard(req: Request<any>, res: Response<any>) 
 	const caller = await Caller.findOne({
 		phone: phone,
 		pinCode: { $eq: req.body.pinCode },
-		$or: [
-			{
-				campaigns: req.body.campaignId
-			},
-			{
-				area: { $eq: req.body.area }
-			}
-		]
+		campaigns: req.body.campaignId
 	});
 	if (!caller) {
 		res.status(404).send({ message: 'Caller not found', OK: false });

--- a/tests/admin/caller/callerInfo.test.ts
+++ b/tests/admin/caller/callerInfo.test.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 import mongoose from 'mongoose';
 import request from 'supertest';
+
 import app from '../../../index';
 import { Area } from '../../../Models/Area';
 import { Call } from '../../../Models/Call';
@@ -45,13 +46,12 @@ beforeAll(async () => {
 		password: 'password'
 	});
 	campaignId = campaign._id;
-	Area.updateOne({ _id: areaId }, { $push: { campaignList: campaignId } });
+	await Area.updateOne({ _id: areaId }, { $push: { campaignList: campaignId } });
 
 	const caller = await Caller.create({
 		name: 'callerInfoTest',
 		phone: '+33634567890',
 		pinCode: '1234',
-		area: areaId,
 		campaigns: [campaignId]
 	});
 	callerId = caller._id;
@@ -104,13 +104,26 @@ describe('post on /admin/caller/callerInfo', () => {
 				adminPassword: adminCode
 			})
 		).id;
+		const Campaign2Id = (
+			await Campaign.create({
+				name: 'callerInfoTest2',
+				script: 'callerInfoTest2',
+				active: false,
+				area: Area2Id,
+				status: [
+					{ name: 'À rappeler', toRecall: true },
+					{ name: 'À retirer', toRecall: false }
+				],
+				password: 'password'
+			})
+		).id;
+		await Area.updateOne({ _id: Area2Id }, { $push: { campaignList: Campaign2Id } });
 		const Caller2Id = (
 			await Caller.create({
 				name: 'callerInfoTest',
 				phone: '+33634567892',
 				pinCode: '1234',
-				area: Area2Id,
-				campaigns: []
+				campaigns: [Campaign2Id]
 			})
 		).id;
 		const res = await request(app).post('/admin/caller/callerInfo').send({

--- a/tests/admin/caller/changeCallerPassword.test.ts
+++ b/tests/admin/caller/changeCallerPassword.test.ts
@@ -1,18 +1,22 @@
 import dotenv from 'dotenv';
 import mongoose from 'mongoose';
 import request from 'supertest';
+
 import app from '../../../index';
 import { Area } from '../../../Models/Area';
 import { Caller } from '../../../Models/Caller';
+import { Campaign } from '../../../Models/Campaign';
 
 dotenv.config({ path: '.env' });
 let areaId: mongoose.Types.ObjectId | undefined;
+let campaignId: mongoose.Types.ObjectId | undefined;
 const adminPassword =
 	'b109f3bbbc244eb82441917ed06d618b9008dd09b3befd1b5e07394c706a8bb980b1d7785e5976ec049b46df5f1326af5a2ea6d103fd07c95385ffab0cacbc86'; //password
 beforeAll(async () => {
 	await mongoose.connect(process.env.URITEST ?? '');
 	await Caller.deleteMany({});
 	await Area.deleteMany({});
+	await Campaign.deleteMany({});
 
 	areaId = (
 		await Area.create({
@@ -22,12 +26,24 @@ beforeAll(async () => {
 			adminPassword: adminPassword
 		})
 	)._id;
+	campaignId = (
+		await Campaign.create({
+			name: 'test',
+			area: areaId,
+			active: true,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+			password: 'password'
+		})
+	)._id;
+	await Area.updateOne({ _id: areaId }, { $push: { campaignList: campaignId } });
+
 	await Caller.create({
 		name: 'changepassordtest',
 		phone: '+33234567890',
 		pinCode: '1234',
 		area: areaId,
-		campaigns: []
+		campaigns: [campaignId]
 	});
 });
 

--- a/tests/admin/caller/changeName.test.ts
+++ b/tests/admin/caller/changeName.test.ts
@@ -1,12 +1,16 @@
 import dotenv from 'dotenv';
 import mongoose from 'mongoose';
 import request from 'supertest';
+
 import app from '../../../index';
 import { Area } from '../../../Models/Area';
 import { Caller } from '../../../Models/Caller';
+import { Campaign } from '../../../Models/Campaign';
 dotenv.config({ path: '.env' });
 let areaId: mongoose.Types.ObjectId | undefined;
 let callerId: mongoose.Types.ObjectId | undefined;
+let campaignId: mongoose.Types.ObjectId | undefined;
+
 const adminPassword =
 	'b109f3bbbc244eb82441917ed06d618b9008dd09b3befd1b5e07394c706a8bb980b1d7785e5976ec049b46df5f1326af5a2ea6d103fd07c95385ffab0cacbc86'; //password
 
@@ -15,6 +19,7 @@ beforeAll(async () => {
 	await Caller.deleteMany({});
 	await Area.deleteMany({});
 	await Caller.deleteMany({});
+	await Campaign.deleteMany({});
 
 	areaId = (
 		await Area.create({
@@ -24,13 +29,26 @@ beforeAll(async () => {
 			adminPassword: adminPassword
 		})
 	)._id;
+
+	campaignId = (
+		await Campaign.create({
+			name: 'test',
+			area: areaId,
+			active: true,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+			password: 'password'
+		})
+	)._id;
+	await Area.updateOne({ _id: areaId }, { $push: { campaignList: campaignId } });
+
 	callerId = (
 		await Caller.create({
 			name: 'changepassordtest',
 			phone: '+33134567890',
 			pinCode: '1234',
 			area: areaId,
-			campaigns: []
+			campaigns: [campaignId]
 		})
 	)?.id;
 });

--- a/tests/admin/caller/exportCallerCsv.test.ts
+++ b/tests/admin/caller/exportCallerCsv.test.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 import mongoose from 'mongoose';
 import request from 'supertest';
+
 import app from '../../../index';
 import { Area } from '../../../Models/Area';
 import { Call } from '../../../Models/Call';
@@ -44,7 +45,6 @@ beforeAll(async () => {
 		name: 'changepassordtest',
 		firstname: 'test',
 		phone: '+33944567890',
-		area: areaId,
 		campaigns: [CampaignID]
 	});
 
@@ -53,7 +53,6 @@ beforeAll(async () => {
 			name: 'changepassordtest',
 			phone: '+33034567891',
 			pinCode: '1234',
-			area: areaId,
 			campaigns: []
 		})
 	).id;
@@ -63,7 +62,6 @@ beforeAll(async () => {
 			name: 'changepassordtest',
 			phone: '+33034567892',
 			pinCode: '1234',
-			area: areaId,
 			campaigns: []
 		})
 	).id;
@@ -73,7 +71,6 @@ beforeAll(async () => {
 			name: 'changepassordtest',
 			phone: '+33034567893',
 			pinCode: '1234',
-			area: areaId,
 			campaigns: []
 		})
 	).id;
@@ -84,8 +81,7 @@ beforeAll(async () => {
 		client: ClientID,
 		campaign: CampaignID,
 		satisfaction: 'all good',
-		status: true,
-		area: areaId
+		status: true
 	});
 
 	await Call.create({
@@ -93,8 +89,7 @@ beforeAll(async () => {
 		client: ClientID,
 		campaign: CampaignID,
 		satisfaction: 'all good',
-		status: true,
-		area: areaId
+		status: true
 	});
 
 	await Call.create({
@@ -102,8 +97,7 @@ beforeAll(async () => {
 		client: ClientID,
 		campaign: CampaignID,
 		satisfaction: 'all good',
-		status: true,
-		area: areaId
+		status: true
 	});
 
 	await Call.create({
@@ -111,8 +105,7 @@ beforeAll(async () => {
 		client: ClientID,
 		campaign: CampaignID,
 		satisfaction: 'all good',
-		status: true,
-		area: areaId
+		status: true
 	});
 
 	await Call.create({
@@ -120,8 +113,7 @@ beforeAll(async () => {
 		client: ClientID,
 		campaign: CampaignID,
 		satisfaction: 'all good',
-		status: true,
-		area: areaId
+		status: true
 	});
 
 	await Call.create({
@@ -129,8 +121,7 @@ beforeAll(async () => {
 		client: ClientID,
 		campaign: CampaignID,
 		satisfaction: 'all good',
-		status: true,
-		area: areaId
+		status: true
 	});
 });
 
@@ -162,7 +153,6 @@ describe('post on /admin/caller/exportCallersCsv', () => {
 			adminCode: 'password',
 			area: areaId
 		});
-		expect(response.status).toBe(200);
 		const expectedPattern = new RegExp(
 			'phone;name;createdAt;nbCall\n' +
 				'\\+33034567891;changepassordtest;.*;1\n' +

--- a/tests/admin/caller/listCaller.test.ts
+++ b/tests/admin/caller/listCaller.test.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 import mongoose from 'mongoose';
 import request from 'supertest';
+
 import app from '../../../index';
 import { Area } from '../../../Models/Area';
 import { Caller } from '../../../Models/Caller';

--- a/tests/admin/caller/listCaller.test.ts
+++ b/tests/admin/caller/listCaller.test.ts
@@ -5,9 +5,12 @@ import request from 'supertest';
 import app from '../../../index';
 import { Area } from '../../../Models/Area';
 import { Caller } from '../../../Models/Caller';
+import { Campaign } from '../../../Models/Campaign';
+
 dotenv.config({ path: '.env' });
 let areaId: mongoose.Types.ObjectId | undefined;
 let callerId: mongoose.Types.ObjectId | undefined;
+let campaignId: mongoose.Types.ObjectId | undefined;
 const adminPassword =
 	'b109f3bbbc244eb82441917ed06d618b9008dd09b3befd1b5e07394c706a8bb980b1d7785e5976ec049b46df5f1326af5a2ea6d103fd07c95385ffab0cacbc86'; //password
 
@@ -16,6 +19,7 @@ beforeAll(async () => {
 	await Caller.deleteMany({});
 	await Area.deleteMany({});
 	await Caller.deleteMany({});
+	await Campaign.deleteMany({});
 
 	areaId = (
 		await Area.create({
@@ -25,6 +29,22 @@ beforeAll(async () => {
 			adminPassword: adminPassword
 		})
 	)._id;
+
+	campaignId = (
+		await Campaign.create({
+			name: 'test',
+			area: areaId,
+			password: 'password',
+			enabled: true,
+			nbMaxCallCampaign: 4,
+			timeBetweenCall: 10_800_000,
+			callHoursStart: new Date(0),
+			callHoursEnd: new Date(0),
+			callPermited: true
+		})
+	)._id;
+
+	await Area.updateOne({ _id: areaId }, { $push: { campaignList: campaignId } });
 });
 
 afterAll(async () => {
@@ -55,7 +75,7 @@ describe('post on /admin/caller/listCaller', () => {
 			await Caller.create({
 				name: 'caller',
 				password: 'password',
-				area: areaId,
+				campaigns: [campaignId],
 				phone: '+33123456789',
 				pinCode: '1234'
 			})
@@ -76,14 +96,14 @@ describe('post on /admin/caller/listCaller', () => {
 			await Area.create({
 				name: 'changepassordtest',
 				password: 'password',
-				campaignList: [],
+				campaignList: [campaignId],
 				adminPassword: adminPassword
 			})
 		)._id;
 		await Caller.create({
 			name: 'caller',
 			password: 'password',
-			area: areaId2,
+			campaigns: [campaignId],
 			phone: '+33123456790',
 			pinCode: '1234'
 		});
@@ -96,6 +116,6 @@ describe('post on /admin/caller/listCaller', () => {
 		expect(res.body.message).toBe('OK');
 		expect(res.body.OK).toBe(true);
 		expect(res.body.data.callers).toBeInstanceOf(Array);
-		expect(res.body.data.numberOfCallers).toBe(1);
+		expect(res.body.data.numberOfCallers).toBe(2);
 	});
 });

--- a/tests/admin/caller/newCaller.test.ts
+++ b/tests/admin/caller/newCaller.test.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 import mongoose from 'mongoose';
 import request from 'supertest';
+
 import app from '../../../index';
 import { Area } from '../../../Models/Area';
 import { Caller } from '../../../Models/Caller';

--- a/tests/admin/caller/searchByName.test.ts
+++ b/tests/admin/caller/searchByName.test.ts
@@ -1,11 +1,15 @@
 import dotenv from 'dotenv';
 import mongoose from 'mongoose';
 import request from 'supertest';
+
 import app from '../../../index';
 import { Area } from '../../../Models/Area';
 import { Caller } from '../../../Models/Caller';
+import { Campaign } from '../../../Models/Campaign';
 dotenv.config({ path: '.env' });
 let areaId: mongoose.Types.ObjectId | undefined;
+let campaignId: mongoose.Types.ObjectId | undefined;
+
 const adminPassword =
 	'b109f3bbbc244eb82441917ed06d618b9008dd09b3befd1b5e07394c706a8bb980b1d7785e5976ec049b46df5f1326af5a2ea6d103fd07c95385ffab0cacbc86'; //password
 
@@ -14,6 +18,7 @@ beforeAll(async () => {
 	await Caller.deleteMany({});
 	await Area.deleteMany({});
 	await Caller.deleteMany({});
+	await Campaign.deleteMany({});
 
 	areaId = (
 		await Area.create({
@@ -23,6 +28,17 @@ beforeAll(async () => {
 			adminPassword: adminPassword
 		})
 	)._id;
+	campaignId = (
+		await Campaign.create({
+			name: 'test',
+			area: areaId,
+			active: true,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+			password: 'password'
+		})
+	)._id;
+	await Area.updateOne({ _id: areaId }, { $push: { campaignList: campaignId } });
 });
 
 afterAll(async () => {
@@ -44,19 +60,19 @@ describe('post on /admin/caller/searchByName', () => {
 		await Caller.create({
 			name: 'name',
 			phone: '+33323456780',
-			area: areaId,
+			campaigns: [campaignId],
 			pinCode: '1234'
 		});
 		await Caller.create({
 			name: 'name1',
 			phone: '+33323456781',
-			area: areaId,
+			campaigns: [campaignId],
 			pinCode: '1234'
 		});
 		await Caller.create({
 			name: 'chose',
 			phone: '+33323456782',
-			area: areaId,
+			campaigns: [campaignId],
 			pinCode: '1234'
 		});
 
@@ -88,19 +104,19 @@ describe('post on /admin/caller/searchByName', () => {
 		await Caller.create({
 			name: 'hello',
 			phone: '+33323456783',
-			area: areaId,
+			campaigns: [campaignId],
 			pinCode: '1234'
 		});
 		await Caller.create({
 			name: 'hello1',
 			phone: '+33323456784',
-			area: areaId,
+			campaigns: [campaignId],
 			pinCode: '1234'
 		});
 		await Caller.create({
 			name: 'truc1',
 			phone: '+33323456785',
-			area: areaId,
+			campaigns: [campaignId],
 			pinCode: '1234'
 		});
 

--- a/tests/admin/caller/searchByPhone.test.ts
+++ b/tests/admin/caller/searchByPhone.test.ts
@@ -1,11 +1,14 @@
 import dotenv from 'dotenv';
 import mongoose from 'mongoose';
 import request from 'supertest';
+
 import app from '../../../index';
 import { Area } from '../../../Models/Area';
 import { Caller } from '../../../Models/Caller';
+import { Campaign } from '../../../Models/Campaign';
 dotenv.config({ path: '.env' });
 let areaId: mongoose.Types.ObjectId | undefined;
+let campaignId: mongoose.Types.ObjectId | undefined;
 const adminPassword =
 	'b109f3bbbc244eb82441917ed06d618b9008dd09b3befd1b5e07394c706a8bb980b1d7785e5976ec049b46df5f1326af5a2ea6d103fd07c95385ffab0cacbc86'; //password
 
@@ -14,6 +17,7 @@ beforeAll(async () => {
 	await Caller.deleteMany({});
 	await Area.deleteMany({});
 	await Caller.deleteMany({});
+	await Campaign.deleteMany({});
 
 	areaId = (
 		await Area.create({
@@ -23,6 +27,18 @@ beforeAll(async () => {
 			adminPassword: adminPassword
 		})
 	)._id;
+
+	campaignId = (
+		await Campaign.create({
+			name: 'test',
+			area: areaId,
+			active: true,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+			password: 'password'
+		})
+	)._id;
+	await Area.updateOne({ _id: areaId }, { $push: { campaignList: campaignId } });
 });
 
 afterAll(async () => {
@@ -44,19 +60,19 @@ describe('post on /admin/caller/searchByPhone', () => {
 		await Caller.create({
 			name: 'name',
 			phone: '+33323456780',
-			area: areaId,
+			campaigns: [campaignId],
 			pinCode: '1234'
 		});
 		await Caller.create({
 			name: 'name1',
 			phone: '+33323456781',
-			area: areaId,
+			campaigns: [campaignId],
 			pinCode: '1234'
 		});
 		await Caller.create({
 			name: 'chose',
 			phone: '+33993456782',
-			area: areaId,
+			campaigns: [campaignId],
 			pinCode: '1234'
 		});
 
@@ -90,19 +106,19 @@ describe('post on /admin/caller/searchByPhone', () => {
 		await Caller.create({
 			name: 'hello',
 			phone: '+33423456783',
-			area: areaId,
+			campaigns: [campaignId],
 			pinCode: '1234'
 		});
 		await Caller.create({
 			name: 'hello1',
 			phone: '+33423456784',
-			area: areaId,
+			campaigns: [campaignId],
 			pinCode: '1234'
 		});
 		await Caller.create({
 			name: 'truc1',
 			phone: '+33593456785',
-			area: areaId,
+			campaigns: [campaignId],
 			pinCode: '1234'
 		});
 

--- a/tests/caller/changeName.test.ts
+++ b/tests/caller/changeName.test.ts
@@ -24,8 +24,7 @@ describe('post on /caller/changeName', () => {
 		const res = await request(app).post('/caller/changeName').send({
 			phone: '0712345678',
 			pinCode: '1234',
-			newName: ' ',
-			area: areaId
+			newName: ' '
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toEqual({ message: 'Wrong newName', OK: false });
@@ -35,8 +34,7 @@ describe('post on /caller/changeName', () => {
 		const res = await request(app).post('/caller/changeName').send({
 			phone: '0712345678',
 			pinCode: '123',
-			newName: 'newName',
-			area: areaId
+			newName: 'newName'
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toEqual({ message: 'Invalid pin code', OK: false });
@@ -46,8 +44,7 @@ describe('post on /caller/changeName', () => {
 		const res = await request(app).post('/caller/changeName').send({
 			phone: '071234567',
 			pinCode: 'abcd',
-			newName: 'newName',
-			area: areaId
+			newName: 'newName'
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toEqual({ message: 'Invalid pin code', OK: false });
@@ -57,14 +54,13 @@ describe('post on /caller/changeName', () => {
 		const res = await request(app).post('/caller/changeName').send({
 			phone: '0712345678',
 			pinCode: '1234',
-			newName: 'newName',
-			area: areaId
+			newName: 'newName'
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toEqual({ message: 'Caller not found', OK: false });
 	});
 
-	it('Should return 200 if user is found', async () => {
+	it('Should return 200 if user is found and new name is set', async () => {
 		await Caller.create({
 			phone: '+33712345678',
 			pinCode: '1234',
@@ -74,14 +70,11 @@ describe('post on /caller/changeName', () => {
 		const res = await request(app).post('/caller/changeName').send({
 			phone: '0712345678',
 			pinCode: '1234',
-			newName: 'newName',
-			area: areaId
+			newName: 'newName'
 		});
 		expect(res.status).toBe(200);
 		expect(res.body).toEqual({ message: 'Caller name changed', OK: true });
-	});
 
-	it('user name should be changed', async () => {
 		const caller = await Caller.findOne({ phone: '+33712345678' });
 		expect(caller?.name).toBe('newName');
 	});

--- a/tests/caller/changePassword.test.ts
+++ b/tests/caller/changePassword.test.ts
@@ -36,8 +36,7 @@ describe('post on /caller/chagePassword', () => {
 		const res = await request(app).post('/caller/changePassword').send({
 			phone: '+34112345681',
 			pinCode: '123',
-			newPin: '1234',
-			area: areaId
+			newPin: '1234'
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toEqual({ message: 'Invalid pin code', OK: false });
@@ -47,8 +46,7 @@ describe('post on /caller/chagePassword', () => {
 		const res = await request(app).post('/caller/changePassword').send({
 			phone: '+34112345681',
 			pinCode: 'abcd',
-			newPin: '1234',
-			area: areaId
+			newPin: '1234'
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toEqual({ message: 'Invalid pin code', OK: false });
@@ -58,8 +56,7 @@ describe('post on /caller/chagePassword', () => {
 		const res = await request(app).post('/caller/changePassword').send({
 			phone: '+34112345682',
 			pinCode: '1234',
-			newPin: '1234',
-			area: areaId
+			newPin: '1234'
 		});
 		expect(res.status).toBe(403);
 		expect(res.body).toEqual({ message: 'Invalid credential', OK: false });
@@ -69,8 +66,7 @@ describe('post on /caller/chagePassword', () => {
 		const res = await request(app).post('/caller/changePassword').send({
 			phone: '+34112345681',
 			pinCode: '1234',
-			newPin: '123',
-			area: areaId
+			newPin: '123'
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toEqual({ message: 'Invalid new pin code', OK: false });
@@ -80,8 +76,7 @@ describe('post on /caller/chagePassword', () => {
 		const res = await request(app).post('/caller/changePassword').send({
 			phone: '+34112345681',
 			pinCode: '1234',
-			newPin: 'ABCD',
-			area: areaId
+			newPin: 'ABCD'
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toEqual({ message: 'Invalid new pin code', OK: false });
@@ -91,8 +86,7 @@ describe('post on /caller/chagePassword', () => {
 		const res = await request(app).post('/caller/changePassword').send({
 			phone: '+34112345681',
 			pinCode: '1234',
-			newPin: '1234',
-			area: areaId
+			newPin: '1234'
 		});
 		expect(res.status).toBe(200);
 		expect(res.body).toEqual({ message: 'password changed', OK: true });
@@ -102,8 +96,7 @@ describe('post on /caller/chagePassword', () => {
 		await request(app).post('/caller/changePassword').send({
 			phone: '+34112345681',
 			pinCode: '1234',
-			newPin: '1235',
-			area: areaId
+			newPin: '1235'
 		});
 		const caller = await Caller.findOne({ phone: '+34112345681' });
 		expect(caller?.pinCode).toBe('1235');

--- a/tests/caller/createCaller.test.ts
+++ b/tests/caller/createCaller.test.ts
@@ -1,14 +1,17 @@
 import dotenv from 'dotenv';
 import mongoose from 'mongoose';
 import request from 'supertest';
+
 import app from '../../index';
 import { Caller } from '../../Models/Caller';
+import { Campaign } from '../../Models/Campaign';
 
 dotenv.config({ path: '.env' });
 let areaId: mongoose.Types.ObjectId | undefined;
 beforeAll(async () => {
 	await mongoose.connect(process.env.URITEST ?? '');
 	await Caller.deleteMany({});
+	await Campaign.deleteMany({});
 });
 
 afterAll(async () => {
@@ -21,7 +24,8 @@ describe('post on /caller/createCaller', () => {
 			phone: '+33912345678',
 			pinCode: '123',
 			newName: 'newName',
-			CallerName: 'name'
+			CallerName: 'name',
+			campaignPassword: 'password'
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toEqual({ message: 'Invalid pin code', OK: false });
@@ -32,7 +36,8 @@ describe('post on /caller/createCaller', () => {
 			phone: '+33912345678',
 			pinCode: 'abcd',
 			newName: 'newName',
-			CallerName: 'name'
+			CallerName: 'name',
+			campaignPassword: 'password'
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toEqual({ message: 'Invalid pin code', OK: false });
@@ -42,39 +47,67 @@ describe('post on /caller/createCaller', () => {
 		const res = await request(app).post('/caller/createCaller').send({
 			phone: '+3391234567',
 			pinCode: '1234',
-			CallerName: 'name'
+			CallerName: 'name',
+			campaignPassword: 'password'
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toEqual({ message: 'Wrong phone number', OK: false });
 	});
 
 	it('Should return 409 if caller already exist', async () => {
+		const campaignid = (
+			await Campaign.create({
+				name: 'Test Campaign',
+				password: 'password',
+				active: true,
+				area: areaId ?? new mongoose.Types.ObjectId()
+			})
+		)._id;
+
 		await Caller.create({
 			phone: '+33912345678',
 			pinCode: '1234',
-			name: 'name'
+			name: 'name',
+			campaigns: [campaignid]
 		});
+
 		const res = await request(app).post('/caller/createCaller').send({
 			phone: '+33912345678',
 			pinCode: '1234',
-			CallerName: 'name'
+			CallerName: 'name',
+			campaignPassword: 'password'
 		});
 		expect(res.status).toBe(409);
 		expect(res.body).toEqual({ message: 'caller already exist', OK: false });
+	});
+});
+describe('post on /caller/createCaller with valid data', () => {
+	let campaignid: mongoose.Types.ObjectId;
+	beforeAll(async () => {
+		campaignid = (
+			await Campaign.create({
+				name: 'Test Campaign',
+				password: 'password2',
+				active: true,
+				area: new mongoose.Types.ObjectId()
+			})
+		)._id;
 	});
 
 	it('Should return 200 if caller is created', async () => {
 		const res = await request(app).post('/caller/createCaller').send({
 			phone: '+33912345679',
 			pinCode: '1234',
-			CallerName: 'name'
+			CallerName: 'name',
+			campaignPassword: 'password2'
 		});
 		expect(res.status).toBe(200);
-		expect(res.body).toEqual({ message: 'Caller created', OK: true });
+		expect(res.body).toMatchObject({ message: 'Caller created', OK: true });
 	});
 
 	it('the caller should be in the database', async () => {
 		const caller = await Caller.findOne({ phone: '+33912345679' });
 		expect(caller?.name).toBe('name');
+		expect(caller?.campaigns).toEqual([campaignid]);
 	});
 });

--- a/tests/caller/createCaller.test.ts
+++ b/tests/caller/createCaller.test.ts
@@ -2,7 +2,6 @@ import dotenv from 'dotenv';
 import mongoose from 'mongoose';
 import request from 'supertest';
 import app from '../../index';
-import { Area } from '../../Models/Area';
 import { Caller } from '../../Models/Caller';
 
 dotenv.config({ path: '.env' });
@@ -10,14 +9,6 @@ let areaId: mongoose.Types.ObjectId | undefined;
 beforeAll(async () => {
 	await mongoose.connect(process.env.URITEST ?? '');
 	await Caller.deleteMany({});
-	await Area.deleteMany({});
-	await Area.create({
-		name: 'changepassordtest',
-		password: 'password',
-		campaignList: [],
-		adminPassword: 'adminPassword'
-	});
-	areaId = (await Area.findOne({ name: 'changepassordtest' }))?._id;
 });
 
 afterAll(async () => {
@@ -30,8 +21,6 @@ describe('post on /caller/createCaller', () => {
 			phone: '+33912345678',
 			pinCode: '123',
 			newName: 'newName',
-			area: areaId,
-			AreaPassword: 'password',
 			CallerName: 'name'
 		});
 		expect(res.status).toBe(400);
@@ -43,8 +32,6 @@ describe('post on /caller/createCaller', () => {
 			phone: '+33912345678',
 			pinCode: 'abcd',
 			newName: 'newName',
-			area: areaId,
-			AreaPassword: 'password',
 			CallerName: 'name'
 		});
 		expect(res.status).toBe(400);
@@ -55,38 +42,21 @@ describe('post on /caller/createCaller', () => {
 		const res = await request(app).post('/caller/createCaller').send({
 			phone: '+3391234567',
 			pinCode: '1234',
-			area: areaId,
-			AreaPassword: 'password',
 			CallerName: 'name'
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toEqual({ message: 'Wrong phone number', OK: false });
 	});
 
-	it('Should return 404 if area not found', async () => {
-		const res = await request(app).post('/caller/createCaller').send({
-			phone: '+33912345678',
-			pinCode: '1234',
-			area: areaId,
-			AreaPassword: 'notpassword',
-			CallerName: 'name'
-		});
-		expect(res.status).toBe(404);
-		expect(res.body).toEqual({ message: 'area not found or invalid password', OK: false });
-	});
-
 	it('Should return 409 if caller already exist', async () => {
 		await Caller.create({
 			phone: '+33912345678',
 			pinCode: '1234',
-			name: 'name',
-			area: areaId
+			name: 'name'
 		});
 		const res = await request(app).post('/caller/createCaller').send({
 			phone: '+33912345678',
 			pinCode: '1234',
-			area: areaId,
-			AreaPassword: 'password',
 			CallerName: 'name'
 		});
 		expect(res.status).toBe(409);
@@ -97,8 +67,6 @@ describe('post on /caller/createCaller', () => {
 		const res = await request(app).post('/caller/createCaller').send({
 			phone: '+33912345679',
 			pinCode: '1234',
-			area: areaId,
-			AreaPassword: 'password',
 			CallerName: 'name'
 		});
 		expect(res.status).toBe(200);

--- a/tests/caller/endCall.test.ts
+++ b/tests/caller/endCall.test.ts
@@ -73,8 +73,7 @@ describe('post on /caller/endCall', () => {
 			pinCode: '1235',
 			timeInCall: 1000,
 			satisfaction: 'In progress',
-			status: true,
-			area: areaId
+			status: true
 		});
 		expect(res.status).toBe(403);
 		expect(res.body).toEqual({ message: 'Invalid credential', OK: false });
@@ -85,7 +84,6 @@ describe('post on /caller/endCall', () => {
 			name: 'changepassordtest3',
 			phone: '+33834567893',
 			pinCode: '1234',
-			area: areaId,
 			campaigns: '66c5db7a64953f8138610d98'
 		});
 
@@ -94,8 +92,7 @@ describe('post on /caller/endCall', () => {
 			pinCode: '1234',
 			timeInCall: 1000,
 			satisfaction: 'Finished',
-			status: true,
-			area: areaId
+			status: true
 		});
 		expect(res.status).toBe(403);
 		expect(res.body).toEqual({ message: 'No call in progress', OK: false });
@@ -106,7 +103,6 @@ describe('post on /caller/endCall', () => {
 			name: 'changepassordtest2',
 			phone: '+33834567892',
 			pinCode: '1234',
-			area: areaId,
 			campaigns: '66c5db7a64953f8138610d98'
 		});
 
@@ -115,16 +111,14 @@ describe('post on /caller/endCall', () => {
 			client: (await Client.findOne({ phone: '+33712457836' }))?._id,
 			campaign: (await Campaign.findOne({ name: 'changepassordtest' }))?._id,
 			satisfaction: 'Finished',
-			status: true,
-			area: areaId
+			status: true
 		});
 		const res = await request(app).post('/caller/endCall').send({
 			phone: '+33834567892',
 			pinCode: '1234',
 			timeInCall: 1000,
 			satisfaction: 'Finished',
-			status: true,
-			area: areaId
+			status: true
 		});
 		expect(res.status).toBe(403);
 		expect(res.body).toEqual({ message: 'No call in progress', OK: false });
@@ -136,8 +130,7 @@ describe('post on /caller/endCall', () => {
 			pinCode: '1234',
 			timeInCall: 1000,
 			satisfaction: 'not in campaign',
-			status: true,
-			area: areaId
+			status: true
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toMatchObject({
@@ -155,14 +148,12 @@ describe('post on /caller/endCall', () => {
 			name: 'changepassordtest2',
 			phone: '+33834567891',
 			pinCode: '1234',
-			area: areaId,
 			campaigns: '66c5db7a64953f8138610d98'
 		});
 		await Client.create({
 			name: 'changepassord',
 			firstname: 'test2',
 			phone: '+33712457837',
-			area: areaId,
 			campaigns: '66c5db7a64953f8138610d98'
 		});
 		await Call.create({
@@ -170,8 +161,7 @@ describe('post on /caller/endCall', () => {
 			client: (await Client.findOne({ phone: '+33712457837' }))?._id,
 			campaign: '66c5db7a64953f8138610d98',
 			satisfaction: 'In progress',
-			status: true,
-			area: areaId
+			status: true
 		});
 
 		const res = await request(app).post('/caller/endCall').send({
@@ -179,8 +169,7 @@ describe('post on /caller/endCall', () => {
 			pinCode: '1234',
 			timeInCall: 1000,
 			satisfaction: 'In progress',
-			status: true,
-			area: areaId
+			status: true
 		});
 		expect(res.status).toBe(500);
 		expect(res.body).toEqual({ message: 'Invalid campaign in call', OK: false });
@@ -191,7 +180,6 @@ describe('post on /caller/endCall', () => {
 			name: 'changepassordtest3',
 			phone: '+33834567894',
 			pinCode: '1234',
-			area: areaId,
 			campaigns: '66c5db7a64953f8138610d98'
 		});
 		await Call.create({
@@ -199,8 +187,7 @@ describe('post on /caller/endCall', () => {
 			client: '66c5db7a64953f8138610d98',
 			campaign: (await Campaign.findOne({ name: 'changepassordtest' }))?._id,
 			satisfaction: 'In progress',
-			status: true,
-			area: areaId
+			status: true
 		});
 	});
 
@@ -210,8 +197,7 @@ describe('post on /caller/endCall', () => {
 			pinCode: '1234',
 			timeInCall: 1000,
 			satisfaction: 'À retirer',
-			status: true,
-			area: areaId
+			status: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body).toEqual({ message: 'Call ended', OK: true });

--- a/tests/caller/giveup.test.ts
+++ b/tests/caller/giveup.test.ts
@@ -43,7 +43,6 @@ beforeAll(async () => {
 		name: 'giveupTest',
 		phone: '+33634567890',
 		pinCode: '1234',
-		area: areaId,
 		campaigns: campaignId
 	});
 	await Client.create({
@@ -62,9 +61,7 @@ describe('post on /caller/giveup', () => {
 	it('should return 400 if phone is invalid', async () => {
 		const res = await request(app).post('/caller/giveup').send({
 			phone: 'invalid',
-			pinCode: '1234',
-			area: areaId,
-			campaign: campaignId
+			pinCode: '1234'
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toMatchObject({ message: 'Invalid phone number', OK: false });
@@ -78,15 +75,13 @@ describe('post on /caller/giveup', () => {
 			campaign: campaignId
 		});
 		expect(res.status).toBe(403);
-		expect(res.body).toMatchObject({ message: 'Invalid credential or incorrect area', OK: false });
+		expect(res.body).toMatchObject({ message: 'Invalid credential', OK: false });
 	});
 
 	it('should return 404 if no call in progress', async () => {
 		const res = await request(app).post('/caller/giveup').send({
 			phone: '+33634567890',
-			pinCode: '1234',
-			area: areaId,
-			campaign: campaignId
+			pinCode: '1234'
 		});
 		expect(res.status).toBe(404);
 		expect(res.body).toMatchObject({ message: 'No call in progress', OK: false });
@@ -101,9 +96,7 @@ describe('post on /caller/giveup', () => {
 		});
 		const res = await request(app).post('/caller/giveup').send({
 			phone: '+33634567890',
-			pinCode: '1234',
-			area: areaId,
-			campaign: campaignId
+			pinCode: '1234'
 		});
 		expect(res.status).toBe(200);
 		expect(res.body).toMatchObject({ message: 'Call ended', OK: true });

--- a/tests/caller/joinCampaign.test.ts
+++ b/tests/caller/joinCampaign.test.ts
@@ -119,5 +119,8 @@ describe('post on /caller/joinCampaign', () => {
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.OK).toBe(true);
+		const caller = await Caller.findOne({ phone: '+33534567900' }, ['campaigns']);
+		expect(caller?.campaigns.includes(out._id)).toBe(true);
+		expect(caller?.campaigns.length).toBe(2);
 	});
 });

--- a/tests/caller/joinCampaign.test.ts
+++ b/tests/caller/joinCampaign.test.ts
@@ -59,8 +59,7 @@ describe('post on /caller/joinCampaign', () => {
 		const res = await request(app).post('/caller/joinCampaign').send({
 			phone: 'invalid',
 			pinCode: '1234',
-			campaignPassword: 'password',
-			campaignId: campaignId
+			campaignPassword: 'password'
 		});
 		expect(res.status).toBe(400);
 		expect(res.body.OK).toBe(false);
@@ -70,8 +69,7 @@ describe('post on /caller/joinCampaign', () => {
 		const res = await request(app).post('/caller/joinCampaign').send({
 			phone: '+33534567901',
 			pinCode: '1234',
-			campaignPassword: 'password',
-			campaignId: campaignId
+			campaignPassword: 'password'
 		});
 		expect(res.status).toBe(403);
 		expect(res.body.OK).toBe(false);
@@ -81,8 +79,7 @@ describe('post on /caller/joinCampaign', () => {
 		const res = await request(app).post('/caller/joinCampaign').send({
 			phone: '+33534567900',
 			pinCode: '1234',
-			campaignPassword: 'password2',
-			campaignId: campaignId
+			campaignPassword: 'password2'
 		});
 		expect(res.status).toBe(404);
 		expect(res.body.OK).toBe(false);
@@ -92,7 +89,6 @@ describe('post on /caller/joinCampaign', () => {
 		const res = await request(app).post('/caller/joinCampaign').send({
 			phone: '+33534567900',
 			pinCode: '1234',
-			campaignId,
 			campaignPassword: 'password'
 		});
 		expect(res.status).toBe(403);
@@ -114,7 +110,6 @@ describe('post on /caller/joinCampaign', () => {
 		const res = await request(app).post('/caller/joinCampaign').send({
 			phone: '+33534567900',
 			pinCode: '1234',
-			campaignId: out._id,
 			campaignPassword: 'password2'
 		});
 		expect(res.status).toBe(200);

--- a/tests/caller/login.test.ts
+++ b/tests/caller/login.test.ts
@@ -30,12 +30,10 @@ beforeAll(async () => {
 		script: 'loginTest',
 		active: true,
 		area: areaId,
-
 		status: [
 			{ name: 'À rappeler', toRecall: true },
 			{ name: 'À retirer', toRecall: false }
 		],
-
 		password: 'password'
 	});
 	campaignId = (await Campaign.findOne({ name: 'loginTest' }))?._id;
@@ -88,7 +86,6 @@ describe('post on /caller/login', () => {
 				name: 'loginTest2',
 				phone: '+33434567902',
 				pinCode: '1234',
-				area: fakeAreaID,
 				campaigns: campaignID2
 			})
 		)?._id;
@@ -99,6 +96,7 @@ describe('post on /caller/login', () => {
 		expect(res.status).toBe(500);
 		expect(res.body.OK).toBe(false);
 	});
+
 	it('should return 200 if all is correct', async () => {
 		const res = await request(app).post('/caller/login').send({
 			phone: '+33434567901',
@@ -106,5 +104,21 @@ describe('post on /caller/login', () => {
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.OK).toBe(true);
+		expect(res.body.data.caller.name).toBe('loginTest');
+		expect(res.body.data.caller.phone).toBe('+33434567901');
+		expect(res.body.data.campaignAvailable.length).toBe(1);
+		expect(res.body.data.campaignAvailable[0].name).toBe('loginTest');
+		expect(res.body.data.campaignAvailable[0].callHoursStart).toBeDefined();
+		expect(res.body.data.campaignAvailable[0].callHoursEnd).toBeDefined();
+		expect(res.body.data.campaignAvailable[0].areaId).toBeDefined();
+		expect(res.body.data.campaignAvailable[0].areaName).toBe('loginTest');
+		expect(res.body.data.campaignAvailable[0].status).toMatchObject([
+			{ name: 'À rappeler', toRecall: true },
+			{ name: 'À retirer', toRecall: false }
+		]);
+		expect(res.body.data.campaignAvailable[0]._id).toBeDefined();
+		expect(res.body.data.campaignAvailable[0].areaId).toBeDefined();
+		expect(res.body.data.campaignAvailable[0].areaId.toString()).toBe(areaId?.toString());
+		expect(res.body.data.campaignAvailable[0]._id.toString()).toBe(campaignId?.toString());
 	});
 });

--- a/tests/caller/validateCall.test.ts
+++ b/tests/caller/validateCall.test.ts
@@ -46,7 +46,6 @@ beforeAll(async () => {
 			name: 'validateCallCaller',
 			phone: '+33334567901',
 			pinCode: '1234',
-			area: areaId,
 			campaigns: campaignId
 		})
 	)._id;
@@ -77,7 +76,7 @@ describe('post on /caller/validateCall', () => {
 		const res = await request(app).post('/caller/validateCall').send({
 			phone: 'invalid',
 			pinCode: '1234',
-			area: areaId,
+			campaign: campaignId,
 			satisfaction: 'À retirer',
 			status: false,
 			phoneNumber: '34567902',
@@ -92,7 +91,7 @@ describe('post on /caller/validateCall', () => {
 		const res = await request(app).post('/caller/validateCall').send({
 			phone: '+33334567901',
 			pinCode: '1234',
-			area: areaId,
+			campaign: campaignId,
 			satisfaction: 'Invalid',
 			status: false,
 			phoneNumber: '+33334567902',
@@ -107,7 +106,7 @@ describe('post on /caller/validateCall', () => {
 		const res = await request(app).post('/caller/validateCall').send({
 			phone: '+33334567901',
 			pinCode: '1235',
-			area: areaId,
+			campaign: campaignId,
 			satisfaction: 'À retirer',
 			status: false,
 			phoneNumber: '+33334567902',
@@ -122,7 +121,7 @@ describe('post on /caller/validateCall', () => {
 		const res = await request(app).post('/caller/validateCall').send({
 			phone: '+33334567903',
 			pinCode: '1234',
-			area: areaId,
+			campaign: campaignId,
 			satisfaction: 'À retirer',
 			status: false,
 			phoneNumber: '+33334567902',
@@ -137,7 +136,7 @@ describe('post on /caller/validateCall', () => {
 		const res = await request(app).post('/caller/validateCall').send({
 			phone: '+33334567901',
 			pinCode: '1234',
-			area: areaId,
+			campaign: campaignId,
 			satisfaction: 'À retirer',
 			status: false,
 			phoneNumber: '+33334567903',
@@ -149,24 +148,10 @@ describe('post on /caller/validateCall', () => {
 	});
 
 	it('should return 404 if campaign is not found', async () => {
-		const areaId = (
-			await Area.create({
-				name: 'validateCall2',
-				password: 'password',
-				campaignList: [],
-				adminPassword: 'adminPassword'
-			})
-		)._id;
-		const caller = await Caller.create({
-			name: 'validateCallCaller2',
-			phone: '+33334567904',
-			pinCode: '1234',
-			area: areaId
-		});
 		const res = await request(app).post('/caller/validateCall').send({
-			phone: caller.phone,
-			pinCode: caller.pinCode,
-			area: areaId,
+			phone: '+33334567901',
+			pinCode: '1234',
+			campaign: new mongoose.Types.ObjectId(),
 			satisfaction: 'À retirer',
 			status: false,
 			phoneNumber: '+33334567904',
@@ -181,7 +166,7 @@ describe('post on /caller/validateCall', () => {
 		const res = await request(app).post('/caller/validateCall').send({
 			phone: '+33334567901',
 			pinCode: '1234',
-			area: areaId,
+			campaign: campaignId,
 			satisfaction: 'À retirer',
 			status: false,
 			phoneNumber: '+33334567903',
@@ -204,7 +189,7 @@ describe('post on /caller/validateCall', () => {
 		const res = await request(app).post('/caller/validateCall').send({
 			phone: '+33334567901',
 			pinCode: '1234',
-			area: areaId,
+			campaign: campaignId,
 			satisfaction: 'À retirer',
 			status: false,
 			phoneNumber: '+33334567905',
@@ -219,7 +204,7 @@ describe('post on /caller/validateCall', () => {
 		const res = await request(app).post('/caller/validateCall').send({
 			phone: '+33334567901',
 			pinCode: '1234',
-			area: areaId,
+			campaign: campaignId,
 			satisfaction: 'À retirer',
 			status: false,
 			phoneNumber: '+33334567902',

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -110,7 +110,6 @@ function cleanStatus(status: 'In progress' | 'to recall' | 'Done' | 'deleted' | 
  * @returns The sanitized string with leading and trailing whitespace removed.
  */
 function sanitizeString(str: string) {
-	str.trim();
 	str = str.replace(/[{,},$]/gm, '');
 	return str.trim();
 }

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -215,16 +215,17 @@ function checkPinCode(pinCode: string, res: Response<any>, orgin: string): boole
 }
 
 function hashPasword(password: string, allreadyHaseded: boolean, res: Response<any>): string | false {
-	if (!allreadyHaseded || password.length != 128) {
-		//create hash
-		password = sha512(password);
-	} else {
-		if (password != sanitizeString(password)) {
-			res.status(400).send({ OK: false, message: 'new password is not a hash' });
-			log(`[${res.req.hostname}] new password is not a hash`, 'WARNING', __filename);
-			return false;
-		}
+	if (!allreadyHaseded || password.length !== 128) {
+		return sha512(password).toString();
 	}
+
+	const isHex = /^[a-fA-F0-9]{128}$/.test(password);
+	if (!isHex) {
+		res.status(400).send({ OK: false, message: 'new password is not a hash' });
+		log(`[${res.req.hostname}] new password is not a hash`, 'WARNING', __filename);
+		return false;
+	}
+
 	return password;
 }
 


### PR DESCRIPTION
## Pull Request Overview

This PR removes the deprecated `area` field from `Caller` records and pivots all caller operations to use `campaign` identifiers instead. Core changes include:

- Schema update: drop `area` from the `Caller` model  
- Route refactoring: replace all `area` parameters and filters with `campaign`  
- Test updates: remove `area` args and inject `campaign` into caller tests

### Reviewed Changes

Copilot reviewed 51 out of 51 changed files in this pull request and generated 1 comment.

<details>
<summary>Show a summary per file</summary>

| File                          | Description                                                      |
|-------------------------------|------------------------------------------------------------------|
| tools/utils.ts                | Strengthened `hashPasword` to validate 128-char hex and return strings consistently  |
| Models/Caller.ts              | Removed the obsolete `area` field from the `Caller` schema       |
| router/caller/\*.ts           | Refactored caller routes (validateCall, login, joinCampaign, giveUp, getProgress, getPhoneNumber, endCall, createCaller) to drop `area` in favor of `campaign`  |
| router/otherCaller/scoreBoard.ts | Updated parameter validation and filters to use `campaign`       |
| router/admin/caller/\*.ts     | Changed admin caller handlers to filter by `campaigns` instead of `area` |
| tests/utils.test.ts           | Adjusted mocks for new `hashPasword` signature                   |
| tests/caller/\*.test.ts       | Removed `area` parameters, added `campaign` where needed         |
| router/admin/caller/\*.ts     | Updated searchByPhone/searchByName/removeCaller/addCallerCampaign/listCaller/exportCallerCsv to use campaigns |
</details>



<details>
<summary>Comments suppressed due to low confidence (4)</summary>

**router/otherCaller/scoreBoard.ts:17**
* The doc comment still references `campaignId` but the code expects `campaign`. Update the API documentation to match the actual parameter name (`campaign`).
```
 * 	"campaignId": mongoDBID
```
**router/otherCaller/scoreBoard.ts:106**
* [nitpick] The log message has a grammatical error. Consider changing to "this caller did not call this client" for clarity.
```
				count: 1,
```
**router/otherCaller/scoreBoard.ts:41**
* [nitpick] Parameter naming is inconsistent across endpoints (`campaign` vs `campaignId`). Standardizing on one name will reduce client confusion.
```
				['campaign', 'ObjectId']
```
**router/caller/getPhoneNumber.ts:20**
* Stale documentation still mentions `area`. Remove or update this to reflect that callers now pass only `campaign`.
```
 *
```
</details>