### PR TITLE
Add validation of client by api without call

### DIFF
--- a/Models/Campaign.ts
+++ b/Models/Campaign.ts
@@ -65,7 +65,8 @@ const CampaignSchema = new mongoose.Schema({
 		require: true,
 		default: [
 			{ name: 'À rappeler', toRecall: true },
-			{ name: 'À retirer', toRecall: false }
+			{ name: 'À retirer', toRecall: false },
+			{ name: '[hide] validate by API', toRecall: false }
 		]
 	},
 	sortGroup: {

--- a/router/admin/area/changeAdminPassword.ts
+++ b/router/admin/area/changeAdminPassword.ts
@@ -14,7 +14,7 @@ import { sha512 } from 'js-sha512';
  * 	"adminCode": string,
  * 	"area": mongoDBID,
  * 	"newPassword": string,
- * 	"allreadyHaseded": boolean
+ * 	"allreadyHashed": boolean
  * }
  *
  * @throws {400}: new password is not a hash
@@ -36,7 +36,7 @@ export default async function ChangeAdminPassword(req: Request<any>, res: Respon
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
 				['newPassword', 'string'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			ip
 		)
@@ -56,7 +56,7 @@ export default async function ChangeAdminPassword(req: Request<any>, res: Respon
 		return;
 	}
 
-	if (!req.body.allreadyHaseded || req.body.newPassword.length != 128) {
+	if (!req.body.allreadyHashed || req.body.newPassword.length != 128) {
 		//create hash
 		req.body.newPassword = sha512(req.body.newPassword);
 	} else {
@@ -67,7 +67,7 @@ export default async function ChangeAdminPassword(req: Request<any>, res: Respon
 		}
 	}
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const update = await Area.updateOne(
 		{ _id: { $eq: req.body.area }, adminPassword: { $eq: password } },

--- a/router/admin/area/changeName.ts
+++ b/router/admin/area/changeName.ts
@@ -34,7 +34,7 @@ export default async function ChangeName(req: Request<any>, res: Response<any>) 
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
 				['newName', 'string'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
@@ -48,7 +48,7 @@ export default async function ChangeName(req: Request<any>, res: Response<any>) 
 	}
 
 	req.body.newName = sanitizeString(req.body.newName);
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const update = await Area.updateOne(
 		{ _id: { $eq: req.body.area }, adminPassword: password },

--- a/router/admin/area/sendSms.ts
+++ b/router/admin/area/sendSms.ts
@@ -17,7 +17,7 @@ export default async function sendSms(req: Request<any>, res: Response<any>) {
 			[
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true],
+				['allreadyHashed', 'boolean', true],
 				['message', 'string']
 			],
 			__filename
@@ -51,7 +51,7 @@ export default async function sendSms(req: Request<any>, res: Response<any>) {
 		}
 	});
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } }, ['adminPhone']);
 	if (!area) {
 		res.status(404).send({ message: 'no area found, or bad password', OK: false });

--- a/router/admin/area/setPhone.ts
+++ b/router/admin/area/setPhone.ts
@@ -16,7 +16,7 @@ export default async function setPhone(req: Request<any>, res: Response<any>) {
 			[
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
@@ -48,7 +48,7 @@ export default async function setPhone(req: Request<any>, res: Response<any>) {
 		phoneCombo[1].trim()
 	]);
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	const area = await Area.updateOne(
 		{ _id: { $eq: req.body.area }, adminPassword: { $eq: password } },
 		{ adminPhone: req.body.phone },

--- a/router/admin/area/smsStatus.ts
+++ b/router/admin/area/smsStatus.ts
@@ -17,14 +17,14 @@ export default async function smsStatus(req: Request<any>, res: Response<any>) {
 			[
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } }, ['adminPhone']);
 	if (!area) {
 		res.status(404).send({ message: 'no area found', OK: false });

--- a/router/admin/caller/addCallerCampaign.ts
+++ b/router/admin/caller/addCallerCampaign.ts
@@ -15,7 +15,7 @@ import { checkParameters, clearPhone, hashPasword } from '../../../tools/utils';
  * 	adminCode: string,
  * 	area: string,
  * 	campaign: string,
- * 	"allreadyHaseded": boolean
+ * 	"allreadyHashed": boolean
  * }
  *
  * @throws {400} if missing parameters
@@ -41,14 +41,14 @@ export default async function addCallerCampaign(req: Request<any>, res: Response
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
 				['campaign', 'string'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } }, [
 		'name',

--- a/router/admin/caller/callerInfo.ts
+++ b/router/admin/caller/callerInfo.ts
@@ -42,7 +42,7 @@ export default async function callerInfo(req: Request<any>, res: Response<any>) 
 				['phone', 'string'],
 				['area', 'ObjectId'],
 				['CampaignId', 'ObjectId', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
@@ -56,7 +56,7 @@ export default async function callerInfo(req: Request<any>, res: Response<any>) 
 		return;
 	}
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 
 	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } }, [

--- a/router/admin/caller/changeCallerPassword.ts
+++ b/router/admin/caller/changeCallerPassword.ts
@@ -15,7 +15,7 @@ import { checkParameters, clearPhone, hashPasword, phoneNumberCheck } from '../.
  * 	"newPassword": string,
  * 	"Callerphone": string,
  * 	"area": string,
- * 	allreadyHaseded: boolean
+ * 	allreadyHashed: boolean
  * }
  *
  * @throws {400}: adminCode is not a hash
@@ -39,7 +39,7 @@ export default async function changeCallerPassword(req: Request<any>, res: Respo
 				['newPassword', 'string'],
 				['Callerphone', 'string'],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
@@ -51,7 +51,7 @@ export default async function changeCallerPassword(req: Request<any>, res: Respo
 		log(`[!${req.body.area}, ${ip}] Invalid new pin code`, 'WARNING', __filename);
 		return;
 	}
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } });
 	if (!area) {

--- a/router/admin/caller/changeName.ts
+++ b/router/admin/caller/changeName.ts
@@ -39,7 +39,7 @@ export default async function ChangeName(req: Request<any>, res: Response<any>) 
 				[`phone`, `string`],
 				[`newName`, `string`],
 				[`area`, `ObjectId`],
-				[`allreadyHaseded`, `boolean`, true]
+				[`allreadyHashed`, `boolean`, true]
 			],
 			__filename
 		)
@@ -59,7 +59,7 @@ export default async function ChangeName(req: Request<any>, res: Response<any>) 
 		return;
 	}
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } });
 	if (!area) {

--- a/router/admin/caller/exportCallerCsv.ts
+++ b/router/admin/caller/exportCallerCsv.ts
@@ -37,13 +37,13 @@ export default async function exportCallerCsv(req: Request<any>, res: Response<a
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
 				['curentCamaign', 'boolean', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } });
 	if (!area) {

--- a/router/admin/caller/listCaller.ts
+++ b/router/admin/caller/listCaller.ts
@@ -36,14 +36,14 @@ export default async function listCaller(req: Request<any>, res: Response<any>) 
 				['area', 'ObjectId'],
 				['skip', 'number', true],
 				['limit', 'number', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } });
 	if (!area) {

--- a/router/admin/caller/newCaller.ts
+++ b/router/admin/caller/newCaller.ts
@@ -43,7 +43,7 @@ export default async function newCaller(req: Request<any>, res: Response<any>) {
 				['pinCode', 'string'],
 				['name', 'string'],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
@@ -64,7 +64,7 @@ export default async function newCaller(req: Request<any>, res: Response<any>) {
 		return;
 	}
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } });
 	if (!area) {

--- a/router/admin/caller/removeCaller.ts
+++ b/router/admin/caller/removeCaller.ts
@@ -37,7 +37,7 @@ export default async function removeCaller(req: Request<any>, res: Response<any>
 				['adminCode', 'string'],
 				['phone', 'string'],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
@@ -51,7 +51,7 @@ export default async function removeCaller(req: Request<any>, res: Response<any>
 		log(`[!${req.body.area}, ${ip}] Wrong phone number for remove caller by admin`, 'WARNING', __filename);
 		return;
 	}
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } });
 	if (!area) {

--- a/router/admin/caller/searchByName.ts
+++ b/router/admin/caller/searchByName.ts
@@ -19,7 +19,7 @@ function escapeRegExp(input: string): string {
  * 	"adminCode": string,
  * 	"name": string,
  * 	"area": string,
- * 	"allreadyHaseded": boolean
+ * 	"allreadyHashed": boolean
  * }
  *
  * @throws {400}: Missing parameters
@@ -41,13 +41,13 @@ export default async function SearchByName(req: Request<any>, res: Response<any>
 				['name', 'string'],
 				['area', 'ObjectId'],
 				['campaign', 'ObjectId', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } });
 	if (!area) {

--- a/router/admin/caller/searchByPhone.ts
+++ b/router/admin/caller/searchByPhone.ts
@@ -35,13 +35,13 @@ export default async function SearchByPhone(req: Request<any>, res: Response<any
 				['adminCode', 'string'],
 				['phone', 'string'],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } });
 	if (!area) {

--- a/router/admin/campaign/GetCampaign.ts
+++ b/router/admin/campaign/GetCampaign.ts
@@ -13,7 +13,7 @@ import { checkParameters, hashPasword } from '../../../tools/utils';
  * 	"adminCode": string,
  * 	"area": mongoDBID,
  * 	"CampaignId"?: mongoDBID,
- * 	"allreadyHaseded": boolean
+ * 	"allreadyHashed": boolean
  * }
  *
  * @throws {400} - Missing parameters
@@ -36,14 +36,14 @@ export default async function getCampaign(req: Request<any>, res: Response<any>)
 				['adminCode', 'string'],
 				['CampaignId', 'string', true],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } }, ['name']);
 	if (!area) {

--- a/router/admin/campaign/addClientCampaign.ts
+++ b/router/admin/campaign/addClientCampaign.ts
@@ -42,7 +42,7 @@ export default async function addClientCampaign(req: Request<any>, res: Response
 				['phone', 'string'],
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
@@ -56,7 +56,7 @@ export default async function addClientCampaign(req: Request<any>, res: Response
 		return;
 	}
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } });
 	if (!area) {

--- a/router/admin/campaign/changeCallHours.ts
+++ b/router/admin/campaign/changeCallHours.ts
@@ -42,14 +42,14 @@ export default async function changeCallHours(req: Request<any>, res: Response<a
 				['newStartHours', 'string'],
 				['area', 'ObjectId'],
 				['CampaignId', 'string', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } });
 	if (!area) {

--- a/router/admin/campaign/changeCampaignPassword.ts
+++ b/router/admin/campaign/changeCampaignPassword.ts
@@ -14,7 +14,7 @@ import { checkParameters, hashPasword, sanitizeString } from '../../../tools/uti
  *	"newCampaignCode": string,
  *	"area": mongoDBID,
  *	"CampaignId": mongoDBID,
- *	"allreadyHaseded": boolean
+ *	"allreadyHashed": boolean
  * }
  *
  * @throws {400} - Missing parameters
@@ -39,13 +39,13 @@ export default async function changeCampaingPassword(req: Request<any>, res: Res
 				['newCampaignCode', 'string'],
 				['area', 'ObjectId'],
 				['CampaignId', 'string', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } });
 	if (!area) {

--- a/router/admin/campaign/changeName.ts
+++ b/router/admin/campaign/changeName.ts
@@ -40,14 +40,14 @@ export default async function changeName(req: Request<any>, res: Response<any>) 
 				['newName', 'string'],
 				['area', 'ObjectId'],
 				['CampaignId', 'string', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } });
 	if (!area) {

--- a/router/admin/campaign/changeNumberMaxCall.ts
+++ b/router/admin/campaign/changeNumberMaxCall.ts
@@ -39,14 +39,14 @@ export default async function changeNumberMaxCall(req: Request<any>, res: Respon
 				['newNumberMaxCall', 'number'],
 				['area', 'ObjectId'],
 				['CampaignId', 'string', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } });
 	if (!area) {

--- a/router/admin/campaign/changeScript.ts
+++ b/router/admin/campaign/changeScript.ts
@@ -14,7 +14,7 @@ import { checkParameters, hashPasword } from '../../../tools/utils';
  *	"newScript": string,
  *	"area": mongoDBID,
  *	"CampaignId": mongoDBID,
- *	"allreadyHaseded": boolean
+ *	"allreadyHashed": boolean
  * }
  *
  * @throws {400} - Missing parameters
@@ -38,14 +38,14 @@ export default async function changeScript(req: Request<any>, res: Response<any>
 				['newScript', 'string'],
 				['area', 'ObjectId'],
 				['CampaignId', 'string', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } });
 	if (!area) {

--- a/router/admin/campaign/changeTimeBetwenCall.ts
+++ b/router/admin/campaign/changeTimeBetwenCall.ts
@@ -14,7 +14,7 @@ import { checkParameters, hashPasword } from '../../../tools/utils';
  *	"area": mongoDBID,
  *	"newTimeBetweenCall": number,
  *	"CampaignId": mongoDBID,
- *	"allreadyHaseded": boolean
+ *	"allreadyHashed": boolean
  * }
  *
  * @throws {400} - Missing parameters
@@ -39,13 +39,13 @@ export default async function changeTimeBetwenCall(req: Request<any>, res: Respo
 				['newTimeBetweenCall', 'number'],
 				['area', 'ObjectId'],
 				['CampaignId', 'string', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } });
 	if (!area) {

--- a/router/admin/campaign/createCampaign.ts
+++ b/router/admin/campaign/createCampaign.ts
@@ -17,7 +17,7 @@ import { log } from '../../../tools/log';
  * 	"callHoursEnd": number,
  * 	"satisfactions": string[],
  * 	"area": mongoDBID,
- *	"allreadyHaseded": boolean
+ *	"allreadyHashed": boolean
  * }
  *
  * @throws {400}: Missing parameters
@@ -45,7 +45,7 @@ export default async function createCampaign(req: Request<any>, res: Response<an
 				['callHoursStart', 'number', true],
 				['callHoursEnd', 'number', true],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
@@ -68,7 +68,7 @@ export default async function createCampaign(req: Request<any>, res: Response<an
 		log(`[!${req.body.area}, ${ip}] Invalid satisfaction`, 'WARNING', __filename);
 		return;
 	}
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } });
 	if (!area) {

--- a/router/admin/campaign/listCallerCampaign.ts
+++ b/router/admin/campaign/listCallerCampaign.ts
@@ -39,14 +39,14 @@ export default async function listCallerCampaign(req: Request<any>, res: Respons
 				['area', 'ObjectId'],
 				['skip', 'number', true],
 				['limit', 'number', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } });
 	if (!area) {

--- a/router/admin/campaign/listCampaign.ts
+++ b/router/admin/campaign/listCampaign.ts
@@ -14,7 +14,7 @@ import { checkParameters, hashPasword } from '../../../tools/utils';
  *	"area": mongoDBID,
  *	"skip": number,
  *	"limit": number,
- * 	"allreadyHaseded": boolean
+ * 	"allreadyHashed": boolean
  * }
  *
  * @throws {400} - Missing parameters
@@ -37,13 +37,13 @@ export default async function listCampaign(req: Request<any>, res: Response<any>
 				['area', 'ObjectId'],
 				['skip', 'number', true],
 				['limit', 'number', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } }, ['name']);
 	if (!area) {

--- a/router/admin/campaign/listClientCampaign.ts
+++ b/router/admin/campaign/listClientCampaign.ts
@@ -16,7 +16,7 @@ import { checkParameters, hashPasword } from '../../../tools/utils';
  *	skip?: number,
  *	limit?: number,
  *	area: string,
- * 	"allreadyHaseded": boolean
+ * 	"allreadyHashed": boolean
  * }
  *
  *	@throws {400} - Missing parameters
@@ -42,13 +42,13 @@ export default async function listClientCampaign(req: Request<any>, res: Respons
 				['skip', 'number', true],
 				['limit', 'number', true],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } });
 	if (!area) {

--- a/router/admin/campaign/setActive.ts
+++ b/router/admin/campaign/setActive.ts
@@ -15,7 +15,7 @@ import { checkParameters, hashPasword } from '../../../tools/utils';
  * 	"active": boolean,
  * 	"campaign": string,
  * 	"area": string,
- * 	"allreadyHaseded": boolean
+ * 	"allreadyHashed": boolean
  * }
  *
  * @throws {400} Missing parameters
@@ -39,14 +39,14 @@ export default async function setActive(req: Request<any>, res: Response<any>) {
 				['active', 'boolean'],
 				['campaign', 'string', true],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } });
 	if (!area) {

--- a/router/admin/campaign/setPriority.ts
+++ b/router/admin/campaign/setPriority.ts
@@ -14,7 +14,7 @@ import { checkParameters, hashPasword, sanitizeString } from '../../../tools/uti
  * 	"priority": Array<{ name: string, id: string(length = 8) }>,
  * 	"area": mongoDBID,
  * 	"CampaignId": mongoDBID,
- * 	"allreadyHaseded": boolean
+ * 	"allreadyHashed": boolean
  * }
  *
  * @throws {400} - Missing parameters
@@ -37,7 +37,7 @@ export default async function setPriority(req: Request<any>, res: Response<any>)
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
 				['CampaignId', 'string', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
@@ -53,7 +53,7 @@ export default async function setPriority(req: Request<any>, res: Response<any>)
 		return;
 	}
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } });
 	if (!area) {

--- a/router/admin/campaign/setSatisfaction.ts
+++ b/router/admin/campaign/setSatisfaction.ts
@@ -72,9 +72,17 @@ export default async function setSatisfaction(req: Request<any>, res: Response<a
 		return;
 	}
 
-	if (!req.body.satisfactions.every((e: any) => typeof e?.name == 'string' && typeof e?.toRecall == 'boolean')) {
+	if (
+		!req.body.satisfactions.every(
+			(e: any) =>
+				typeof e?.name === 'string' &&
+				typeof e?.toRecall === 'boolean' &&
+				!e?.name.includes('[hide] validate by API')
+		)
+	) {
 		res.status(400).send({
-			message: 'Invalid satisfaction, satisfactions must be a array<{ name: String, toRecall: Boolean }>',
+			message:
+				'Invalid satisfaction, satisfactions must be a array<{ name: String, toRecall: Boolean }> name dont contain "[hide] validate by API"',
 			OK: false
 		});
 		log(`[${req.body.area}, ${ip}] Invalid satisfaction`, 'WARNING', __filename);
@@ -85,6 +93,8 @@ export default async function setSatisfaction(req: Request<any>, res: Response<a
 		name: sanitizeString(e.name),
 		toRecall: e.toRecall
 	}));
+
+	req.body.satisfactions.push({ name: '[hide] validate by API', toRecall: false });
 
 	await Campaign.updateOne({ _id: campaign._id }, { status: req.body.satisfactions });
 	res.status(200).send({ message: 'Satisfaction updated', OK: true });

--- a/router/admin/campaign/setSatisfaction.ts
+++ b/router/admin/campaign/setSatisfaction.ts
@@ -14,7 +14,7 @@ import { checkParameters, hashPasword, sanitizeString } from '../../../tools/uti
  * 	"satisfactions": Array<{ name: string, toRecall: boolean }>,
  * 	"area": mongoDBID,
  * 	"CampaignId": mongoDBID,
- * 	"allreadyHaseded": boolean
+ * 	"allreadyHashed": boolean
  * }
  *
  * @throws {400} - Missing parameters
@@ -37,7 +37,7 @@ export default async function setSatisfaction(req: Request<any>, res: Response<a
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
 				['CampaignId', 'string', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
@@ -50,7 +50,7 @@ export default async function setSatisfaction(req: Request<any>, res: Response<a
 		return;
 	}
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } });
 	if (!area) {

--- a/router/admin/client/clientInfo.ts
+++ b/router/admin/client/clientInfo.ts
@@ -43,7 +43,7 @@ export default async function clientInfo(req: Request<any>, res: Response<any>) 
 				['phone', 'string'],
 				['area', 'ObjectId'],
 				['campaign', 'string', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
@@ -57,7 +57,7 @@ export default async function clientInfo(req: Request<any>, res: Response<any>) 
 		return;
 	}
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } });
 	if (!area) {

--- a/router/admin/client/createClient.ts
+++ b/router/admin/client/createClient.ts
@@ -53,7 +53,7 @@ export default async function createClient(req: Request<any>, res: Response<any>
 				['institution', 'string', true],
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true],
+				['allreadyHashed', 'boolean', true],
 				['updateIfExist', 'boolean', true],
 				['updateKey', 'ObjectId', true],
 				['firstIntegration', 'Date', true],
@@ -63,7 +63,7 @@ export default async function createClient(req: Request<any>, res: Response<any>
 		)
 	)
 		return;
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 
 	if (

--- a/router/admin/client/createClients.ts
+++ b/router/admin/client/createClients.ts
@@ -13,7 +13,7 @@ import { checkParameters, clearPhone, hashPasword, phoneNumberCheck, sanitizeStr
  * 	"adminCode": string,
  * 	"area": string,
  * 	"data": [{phone:string, name?:string, firstname?:string, institution?:string, priority?:string, firstIntegration?:date, integrationReason?:string}],
- * 	"allreadyHaseded": boolean
+ * 	"allreadyHashed": boolean
  * 	"defaultReason": string
  * }
  * @throws {400}: missing parameters,
@@ -35,7 +35,7 @@ export default async function createClients(req: Request<any>, res: Response<any
 			[
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true],
+				['allreadyHashed', 'boolean', true],
 				['defaultReason', 'string', true]
 			],
 			ip
@@ -78,7 +78,7 @@ export default async function createClients(req: Request<any>, res: Response<any
 		return;
 	}
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 
 	const area = await Area.findOne(

--- a/router/admin/client/exportClientsCsv.ts
+++ b/router/admin/client/exportClientsCsv.ts
@@ -41,13 +41,13 @@ export default async function exportClientCsv(req: Request<any>, res: Response<a
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
 				['CampaignId', 'string', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } }, ['name']);
 	if (!area) {

--- a/router/admin/client/removeAllClients.ts
+++ b/router/admin/client/removeAllClients.ts
@@ -38,13 +38,13 @@ export default async function removeAllClients(req: Request<any>, res: Response<
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
 				['CampaignId', 'string', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } });
 	if (!area) {

--- a/router/admin/client/removeClient.ts
+++ b/router/admin/client/removeClient.ts
@@ -41,13 +41,13 @@ export default async function removeClient(req: Request<any>, res: Response<any>
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
 				['CampaignId', 'string', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	req.body.phone = clearPhone(req.body.phone);
 	if (!phoneNumberCheck(req.body.phone)) {

--- a/router/admin/client/searchByName.ts
+++ b/router/admin/client/searchByName.ts
@@ -40,14 +40,14 @@ export default async function SearchByName(req: Request<any>, res: Response<any>
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
 				['CampaignId', 'string', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } });
 	if (!area) {

--- a/router/admin/client/searchByPhone.ts
+++ b/router/admin/client/searchByPhone.ts
@@ -35,13 +35,13 @@ export default async function SearchByPhone(req: Request<any>, res: Response<any
 				['phone', 'string'],
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } });
 	if (!area) {

--- a/router/admin/client/searchComplete.ts
+++ b/router/admin/client/searchComplete.ts
@@ -43,14 +43,14 @@ export default async function searchComplete(req: Request<any>, res: Response<an
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
 				['CampaignId', 'string', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } }, ['_id']);
 	if (!area) {

--- a/router/admin/client/searchComplete.ts
+++ b/router/admin/client/searchComplete.ts
@@ -3,7 +3,7 @@ import { Request, Response } from 'express';
 import { Area } from '../../../Models/Area';
 import { Campaign } from '../../../Models/Campaign';
 import { log } from '../../../tools/log';
-import { checkParameters, hashPasword, partialShearchClient } from '../../../tools/utils';
+import { checkParameters, hashPasword, partialSearchClient } from '../../../tools/utils';
 
 /**
  * Search for clients with name, fist name and patial phone
@@ -66,7 +66,7 @@ export default async function searchComplete(req: Request<any>, res: Response<an
 		campaign = await Campaign.findOne({ area: area._id, active: true }, ['_id']);
 	}
 
-	const result = await partialShearchClient(
+	const result = await partialSearchClient(
 		campaign,
 		req.body.name,
 		req.body.firstName,

--- a/router/admin/client/validateByAPI.ts
+++ b/router/admin/client/validateByAPI.ts
@@ -2,9 +2,10 @@ import { Request, Response } from 'express';
 
 import { Area } from '../../../Models/Area';
 import { Call } from '../../../Models/Call';
+import { Caller } from '../../../Models/Caller';
 import { Campaign } from '../../../Models/Campaign';
 import { log } from '../../../tools/log';
-import { checkParameters, getApiCaller, hashPasword, partialSearchClient, sanitizeString } from '../../../tools/utils';
+import { checkParameters, hashPasword, partialSearchClient, sanitizeString } from '../../../tools/utils';
 
 /**
  * Search for clients with name, fist name and patial phone
@@ -114,4 +115,22 @@ export default async function validateByAPI(req: Request<any>, res: Response<any
 
 	res.status(200).send({ message: 'this client has been validate', OK: true });
 	log(`[${req.body.area}, ${ip}] client ${result.data._id} has ben validate`, 'INFO', __filename);
+
+	async function getApiCaller() {
+		let caller: InstanceType<typeof Caller> | null = await Caller.findOne({
+			name: 'API Caller',
+			phone: '+33000000000',
+			pinCode: '1970'
+		});
+		if (!caller) {
+			caller = await new Caller({
+				name: 'API Caller',
+				phone: '+33000000000',
+				pinCode: '1970',
+				campaigns: await Campaign.find({}, [])
+			}).save();
+		}
+
+		return caller;
+	}
 }

--- a/router/admin/client/validateByAPI.ts
+++ b/router/admin/client/validateByAPI.ts
@@ -46,14 +46,14 @@ export default async function validateByAPI(req: Request<any>, res: Response<any
 				['phoneFragmentStart', 'string', true],
 				['phoneFragmentEnd', 'string', true],
 				['CampaignId', 'string', true],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } }, ['_id']);
 	if (!area) {
@@ -93,6 +93,7 @@ export default async function validateByAPI(req: Request<any>, res: Response<any
 
 	if (allreadyCalled) {
 		res.status(200).send({ message: 'this client is already called by an reel caller', OK: true });
+		return;
 	}
 
 	const APICaller = await getApiCaller();

--- a/router/admin/client/validateByAPI.ts
+++ b/router/admin/client/validateByAPI.ts
@@ -83,7 +83,7 @@ export default async function validateByAPI(req: Request<any>, res: Response<any
 	);
 
 	if (!result.OK || !result.data || !result.data['_id']) {
-		res.status(404).send(result);
+		res.status(404).send({ message: 'no clients found on second pass', OK: false });
 		log(`[${req.body.area}, ${ip}] no clients found on second pass`, 'INFO', __filename);
 		return;
 	}
@@ -91,7 +91,7 @@ export default async function validateByAPI(req: Request<any>, res: Response<any
 	const allreadyCalled = await Call.findOne({ client: result.data._id, campaign: campaign._id, status: false });
 
 	if (allreadyCalled) {
-		res.status(200).send('this client is already called by an reel caller');
+		res.status(200).send({ message: 'this client is already called by an reel caller', OK: true });
 	}
 
 	const APICaller = await getApiCaller();

--- a/router/admin/client/validateByAPI.ts
+++ b/router/admin/client/validateByAPI.ts
@@ -1,10 +1,10 @@
 import { Request, Response } from 'express';
 
-import { Call } from '../../../Models/Call';
 import { Area } from '../../../Models/Area';
+import { Call } from '../../../Models/Call';
 import { Campaign } from '../../../Models/Campaign';
 import { log } from '../../../tools/log';
-import { checkParameters, getApiCaller, hashPasword, partialShearchClient, sanitizeString } from '../../../tools/utils';
+import { checkParameters, getApiCaller, hashPasword, partialSearchClient, sanitizeString } from '../../../tools/utils';
 
 /**
  * Search for clients with name, fist name and patial phone
@@ -74,7 +74,7 @@ export default async function validateByAPI(req: Request<any>, res: Response<any
 		return;
 	}
 
-	const result = await partialShearchClient(
+	const result = await partialSearchClient(
 		campaign,
 		req.body.name,
 		req.body.firstName,
@@ -86,6 +86,12 @@ export default async function validateByAPI(req: Request<any>, res: Response<any
 		res.status(404).send(result);
 		log(`[${req.body.area}, ${ip}] no clients found on second pass`, 'INFO', __filename);
 		return;
+	}
+
+	const allreadyCalled = await Call.findOne({ client: result.data._id, campaign: campaign._id, status: false });
+
+	if (allreadyCalled) {
+		res.status(200).send('this client is already called by an reel caller');
 	}
 
 	const APICaller = await getApiCaller();

--- a/router/admin/login.ts
+++ b/router/admin/login.ts
@@ -13,7 +13,7 @@ import { checkParameters, hashPasword } from '../../tools/utils';
  * body: {
  * 	adminCode: 'adminCode',
  * 	area: 'areaId'
- * 	allreadyHaseded: boolean
+ * 	allreadyHashed: boolean
  * }
  *
  * response: {
@@ -49,14 +49,14 @@ export default async function login(req: Request<any>, res: Response<any>) {
 			[
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			'login.ts'
 		)
 	)
 		return;
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: password });
 	if (!area) {

--- a/router/admin/stats/call.ts
+++ b/router/admin/stats/call.ts
@@ -15,7 +15,7 @@ import { checkParameters, hashPasword } from '../../../tools/utils';
  * 	CampaignId: ObjectId,
  * 	adminCode: String,
  * 	area: ObjectId,
- *	"allreadyHaseded": boolean
+ *	"allreadyHashed": boolean
  * }
  *
  * @throws {400} Missing parameters
@@ -38,14 +38,14 @@ export default async function call(req: Request<any>, res: Response<any>) {
 				['CampaignId', 'ObjectId', true],
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } });
 	if (!area) {

--- a/router/admin/stats/call.ts
+++ b/router/admin/stats/call.ts
@@ -64,8 +64,6 @@ export default async function call(req: Request<any>, res: Response<any>) {
 		return;
 	}
 
-	console.log(campaign._id);
-
 	const result = await Call.aggregate([
 		{
 			$match: {
@@ -130,10 +128,8 @@ export default async function call(req: Request<any>, res: Response<any>) {
 		}
 	]);
 
-	// Compte des utilisateurs dans la campagne
 	const totalUser = await Client.countDocuments({ campaigns: campaign });
 
-	console.log(await result);
 	res.status(200).send({
 		message: 'OK',
 		OK: true,

--- a/router/admin/stats/callByDate.ts
+++ b/router/admin/stats/callByDate.ts
@@ -14,7 +14,7 @@ import { checkParameters, hashPasword } from '../../../tools/utils';
  * 	CampaignId: ObjectId,
  * 	adminCode: String,
  * 	area: ObjectId,
- * 	"allreadyHaseded": boolean
+ * 	"allreadyHashed": boolean
  * }
  *
  * @throws {400} Missing parameters
@@ -36,13 +36,13 @@ export default async function callByDate(req: Request<any>, res: Response<any>) 
 				['CampaignId', 'string', true],
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ adminPassword: { $eq: password }, _id: { $eq: req.body.area } }, ['name']);
 	if (!area) {

--- a/router/admin/stats/callByDate.ts
+++ b/router/admin/stats/callByDate.ts
@@ -68,7 +68,13 @@ export default async function callByDate(req: Request<any>, res: Response<any>) 
 
 	const NbCall = await Call.countDocuments({ campaign: campaign._id });
 	let i = 0;
-	await Call.find({ campaign: campaign._id })
+	await Call.find({
+		campaign: campaign._id,
+		satisfaction: {
+			$not: { $regex: /^\[hide\]/ }
+		},
+		$expr: { $ne: ['$satisfaction', null] }
+	})
 		.cursor()
 		.eachAsync(call => {
 			res.write(

--- a/router/admin/stats/numberOfCallers.ts
+++ b/router/admin/stats/numberOfCallers.ts
@@ -14,7 +14,7 @@ import { checkParameters, hashPasword } from '../../../tools/utils';
  * 	CampaignId: ObjectId,
  * 	adminCode: String,
  * 	area: ObjectId,
- * 	"allreadyHaseded": boolean
+ * 	"allreadyHashed": boolean
  * }
  *
  * @throws {400} Missing parameters
@@ -36,13 +36,13 @@ export default async function numberOfCallers(req: Request<any>, res: Response<a
 				['campaign', 'string', true],
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } });
 	if (!area) {

--- a/router/admin/stats/response.ts
+++ b/router/admin/stats/response.ts
@@ -19,14 +19,14 @@ export default async function response(req: Request<any>, res: Response<any>) {
 				['CampaignId', 'string', true],
 				['adminCode', 'string'],
 				['area', 'ObjectId'],
-				['allreadyHaseded', 'boolean', true]
+				['allreadyHashed', 'boolean', true]
 			],
 			__filename
 		)
 	)
 		return;
 
-	const password = hashPasword(req.body.adminCode, req.body.allreadyHaseded, res);
+	const password = hashPasword(req.body.adminCode, req.body.allreadyHashed, res);
 	if (!password) return;
 	const area = await Area.findOne({ _id: { $eq: req.body.area }, adminPassword: { $eq: password } }, ['name']);
 	if (!area) {

--- a/router/caller/getPhoneNumber.ts
+++ b/router/caller/getPhoneNumber.ts
@@ -242,7 +242,6 @@ export default async function getPhoneNumber(req: Request<any>, res: Response<an
 
 			//keep only the first client
 			{ $limit: 1 },
-
 			// Return only selected fields
 			{
 				$project: {

--- a/routes.ts
+++ b/routes.ts
@@ -39,6 +39,7 @@ import removeClient from './router/admin/client/removeClient';
 import SearchClientByName from './router/admin/client/searchByName';
 import SearchClientByPhone from './router/admin/client/searchByPhone';
 import searchComplete from './router/admin/client/searchComplete';
+import validateByAPI from './router/admin/client/validateByAPI';
 import loginAdmin from './router/admin/login';
 import call from './router/admin/stats/call';
 import callByDate from './router/admin/stats/callByDate';
@@ -89,6 +90,7 @@ router.post('/admin/client/removeClients', removeAllClients);
 router.post('/admin/client/createClient', createClient);
 router.post('/admin/client/clientInfo', clientInfo);
 router.post('/admin/client/exportClientsCsv', exportClientCsv);
+router.post('/admin/client/validateByAPI', validateByAPI);
 
 //admin/area
 router.post('/admin/area/changeName', ChangeAreaName);

--- a/tests/admin/area/changeAdminPassword.test.ts
+++ b/tests/admin/area/changeAdminPassword.test.ts
@@ -64,7 +64,7 @@ describe('post on /admin/area/changeAdminPassword', () => {
 			area: areaId,
 			newPassword:
 				'6f63f637f1346149532158022899bdf424a19c3dc472e21c2068cd324d7263ed521fb1c1335afaad6bf3fd94a24c0371217086295255e7773eb8deb2c7a54e1{',
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toHaveProperty('message', 'new password is not a hash');
@@ -102,7 +102,7 @@ describe('post on /admin/area/changeAdminPassword', () => {
 			adminCode: password,
 			area: areaId2,
 			newPassword: newAreaPassword,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body).toHaveProperty('message', 'password of area changed');

--- a/tests/admin/area/changeName.test.ts
+++ b/tests/admin/area/changeName.test.ts
@@ -31,7 +31,7 @@ describe('post on /admin/area/changeName', () => {
 			adminCode: adminPassword,
 			area: areaId,
 			newName: ' ',
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toHaveProperty('message', 'bad new name');
@@ -44,7 +44,7 @@ describe('post on /admin/area/changeName', () => {
 				adminCode: adminPassword,
 				area: areaId,
 				newName: 'a'.repeat(51),
-				allreadyHaseded: true
+				allreadyHashed: true
 			});
 		expect(res.status).toBe(400);
 		expect(res.body).toHaveProperty('message', 'bad new name');
@@ -55,7 +55,7 @@ describe('post on /admin/area/changeName', () => {
 			adminCode: adminPassword,
 			area: new mongoose.Types.ObjectId(),
 			newName: 'newName',
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(404);
 		expect(res.body).toHaveProperty('message', 'no area found');
@@ -88,7 +88,7 @@ describe('post on /admin/area/changeName', () => {
 			adminCode: adminPassword,
 			area: areaId,
 			newName: 'newName2',
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body).toHaveProperty('message', 'name of area changed');

--- a/tests/admin/area/sendSms.test.ts
+++ b/tests/admin/area/sendSms.test.ts
@@ -100,7 +100,7 @@ describe('POST /admin/area/sendSms', () => {
 			.post('/admin/area/sendSms')
 			.send({
 				adminCode: adminPassword,
-				allreadyHaseded: true,
+				allreadyHashed: true,
 				area: areaId,
 				phone: [
 					['0701234567', 'John'],

--- a/tests/admin/area/setPhone.test.ts
+++ b/tests/admin/area/setPhone.test.ts
@@ -98,7 +98,7 @@ describe('POST /admin/area/setPhone', () => {
 				adminCode: adminPassword,
 				area: areaId,
 				phone: [['0701234567', 'John']],
-				allreadyHaseded: true
+				allreadyHashed: true
 			});
 		expect(res.status).toBe(200);
 		expect(res.body).toHaveProperty('OK', true);

--- a/tests/admin/area/smsStatus.test.ts
+++ b/tests/admin/area/smsStatus.test.ts
@@ -34,7 +34,7 @@ describe('post on /admin/area/smsStatus', () => {
 		const response = await request(app).post('/admin/area/smsStatus').send({
 			adminCode: 'password',
 			area: areaId?.toString(),
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 
 		expect(response.status).toBe(200);
@@ -48,7 +48,7 @@ describe('post on /admin/area/smsStatus', () => {
 		const response = await request(app).post('/admin/area/smsStatus').send({
 			adminCode: 'bad',
 			area: areaId?.toString(),
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 
 		expect(response.status).toBe(404);
@@ -61,7 +61,7 @@ describe('post on /admin/area/smsStatus', () => {
 		const response = await request(app).post('/admin/area/smsStatus').send({
 			adminCode: 'password',
 			area: areaId?.toString(),
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 
 		expect(response.status).toBe(200);

--- a/tests/admin/caller/addCallerCampaign.test.ts
+++ b/tests/admin/caller/addCallerCampaign.test.ts
@@ -74,7 +74,7 @@ describe('post on /admin/caller/addCallerCampaign', () => {
 			adminCode: adminPassword,
 			area: areaId,
 			campaign: campaignId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(404);
 		expect(res.body.message).toBe('Caller not found');
@@ -92,7 +92,7 @@ describe('post on /admin/caller/addCallerCampaign', () => {
 			adminCode: adminPassword,
 			area: areaId,
 			campaign: campaignId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 
 		expect(res.status).toBe(200);
@@ -130,7 +130,7 @@ describe('post on /admin/caller/addCallerCampaign', () => {
 			adminCode: adminPassword,
 			area: areaId,
 			campaign: campaignId2,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.message).toBe('Caller added to campaign');

--- a/tests/admin/caller/callerInfo.test.ts
+++ b/tests/admin/caller/callerInfo.test.ts
@@ -67,7 +67,7 @@ describe('post on /admin/caller/callerInfo', () => {
 			adminCode: adminCode,
 			phone: 'invalid',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toHaveProperty('message', 'Wrong phone number');
@@ -78,7 +78,7 @@ describe('post on /admin/caller/callerInfo', () => {
 			adminCode: adminCode,
 			phone: '+33634567890',
 			area: new mongoose.Types.ObjectId(),
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(404);
 		expect(res.body).toHaveProperty('message', 'no area found');
@@ -89,7 +89,7 @@ describe('post on /admin/caller/callerInfo', () => {
 			adminCode: adminCode,
 			phone: '+33634567891',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(404);
 		expect(res.body).toHaveProperty('message', 'no caller found');
@@ -130,7 +130,7 @@ describe('post on /admin/caller/callerInfo', () => {
 			adminCode: adminCode,
 			phone: '+33634567892',
 			area: Area2Id,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(404);
 		expect(res.body).toHaveProperty('message', 'no campaign active');
@@ -141,7 +141,7 @@ describe('post on /admin/caller/callerInfo', () => {
 			adminCode: adminCode,
 			phone: '+33634567890',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		const reg = new RegExp(`{

--- a/tests/admin/caller/changeCallerPassword.test.ts
+++ b/tests/admin/caller/changeCallerPassword.test.ts
@@ -115,7 +115,7 @@ describe('post on /admin/caller/changePassword', () => {
 			newPassword: '1235',
 			Callerphone: '+33234567890',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(response.status).toBe(200);
 		expect(response.body).toMatchObject({ message: 'Password changed', OK: true });

--- a/tests/admin/caller/changeName.test.ts
+++ b/tests/admin/caller/changeName.test.ts
@@ -107,7 +107,7 @@ describe('post on /admin/caller/changeName', () => {
 			newName: 'newName',
 			phone: '+33134567890',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(response.status).toBe(200);
 		expect(response.body).toMatchObject({ message: 'Caller name changed', OK: true });

--- a/tests/admin/caller/exportCallerCsv.test.ts
+++ b/tests/admin/caller/exportCallerCsv.test.ts
@@ -167,7 +167,7 @@ describe('post on /admin/caller/exportCallersCsv', () => {
 		const response = await request(app).post('/admin/caller/exportCallersCsv').send({
 			adminCode: adminPassword,
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(response.status).toBe(200);
 		const expectedPattern = new RegExp(

--- a/tests/admin/caller/listCaller.test.ts
+++ b/tests/admin/caller/listCaller.test.ts
@@ -110,7 +110,7 @@ describe('post on /admin/caller/listCaller', () => {
 		const res = await request(app).post('/admin/caller/listCaller').send({
 			adminCode: adminPassword,
 			area: areaId2,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.message).toBe('OK');

--- a/tests/admin/caller/newCaller.test.ts
+++ b/tests/admin/caller/newCaller.test.ts
@@ -107,7 +107,7 @@ describe('post on /admin/caller/createCaller', () => {
 			phone: '+33223456782',
 			pinCode: '1234',
 			name: 'caller',
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body).toHaveProperty('message', 'Caller caller (+33223456782) created');

--- a/tests/admin/caller/removeCaller.test.ts
+++ b/tests/admin/caller/removeCaller.test.ts
@@ -103,7 +103,7 @@ describe('post on /admin/caller/removeCaller', () => {
 			adminCode: adminPassword,
 			area: areaId,
 			phone: '+33223456781',
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body).toHaveProperty('message', 'Caller removed');

--- a/tests/admin/caller/searchByName.test.ts
+++ b/tests/admin/caller/searchByName.test.ts
@@ -124,7 +124,7 @@ describe('post on /admin/caller/searchByName', () => {
 			adminCode: adminPassword,
 			area: areaId,
 			name: 'hello',
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body).toHaveProperty('OK', true);
@@ -137,7 +137,7 @@ describe('post on /admin/caller/searchByName', () => {
 			adminCode: adminPassword,
 			area: areaId,
 			name: 'truc',
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res2.status).toBe(200);
 		expect(res2.body).toHaveProperty('OK', true);

--- a/tests/admin/caller/searchByPhone.test.ts
+++ b/tests/admin/caller/searchByPhone.test.ts
@@ -126,7 +126,7 @@ describe('post on /admin/caller/searchByPhone', () => {
 			adminCode: adminPassword,
 			area: areaId,
 			phone: '+334',
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body).toHaveProperty('message', 'OK');
@@ -140,7 +140,7 @@ describe('post on /admin/caller/searchByPhone', () => {
 			adminCode: adminPassword,
 			area: areaId,
 			phone: '+335',
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res1.status).toBe(200);
 		expect(res1.body).toHaveProperty('message', 'OK');

--- a/tests/admin/campaign/addClientCampaign.test.ts
+++ b/tests/admin/campaign/addClientCampaign.test.ts
@@ -68,7 +68,7 @@ describe('post on /admin/campaign/addClientCampaign', () => {
 			phone: 'bad phone number',
 			adminCode,
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(400);
 		expect(res.body).toEqual({ message: 'Wrong phone number', OK: false });
@@ -89,7 +89,7 @@ describe('post on /admin/campaign/addClientCampaign', () => {
 			phone: '+33634567891',
 			adminCode,
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(404);
 		expect(res.body).toEqual({ message: 'User not found', OK: false });
@@ -100,7 +100,7 @@ describe('post on /admin/campaign/addClientCampaign', () => {
 			phone: '+33634567890',
 			adminCode,
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(404);
 		expect(res.body).toEqual({ message: 'Campaign not found', OK: false });
@@ -144,7 +144,7 @@ describe('post on /admin/campaign/addClientCampaign', () => {
 			phone: '+33634567890',
 			adminCode,
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body).toEqual({ message: 'User already in campaign', OK: true });
@@ -164,7 +164,7 @@ describe('post on /admin/campaign/addClientCampaign', () => {
 			phone: '+33634567893',
 			adminCode,
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body).toEqual({ message: 'User added to campaign', OK: true });

--- a/tests/admin/campaign/changeCallHours.test.ts
+++ b/tests/admin/campaign/changeCallHours.test.ts
@@ -56,7 +56,7 @@ describe('post on /admin/campaign/changeCallHours', () => {
 			newEndHours: '2022-10-10T10:00:00.000Z',
 			newStartHours: 'bad date',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(400);
 		expect(res.body.OK).toBe(false);
@@ -69,7 +69,7 @@ describe('post on /admin/campaign/changeCallHours', () => {
 			newEndHours: 'bad date',
 			newStartHours: '2022-10-10T10:00:00.000Z',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(400);
 		expect(res.body.OK).toBe(false);
@@ -95,7 +95,7 @@ describe('post on /admin/campaign/changeCallHours', () => {
 			newStartHours: '2022-10-10T10:00:00.000Z',
 			area: areaId,
 			CampaignId: new Types.ObjectId().toHexString(),
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(401);
 		expect(res.body.OK).toBe(false);
@@ -113,7 +113,7 @@ describe('post on /admin/campaign/changeCallHours', () => {
 			newEndHours: end,
 			area: areaId,
 			CampaignId: campaignId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.OK).toBe(true);

--- a/tests/admin/campaign/changeCampaignPassword.test.ts
+++ b/tests/admin/campaign/changeCampaignPassword.test.ts
@@ -67,7 +67,7 @@ describe('post on /admin/campaign/changePassword', () => {
 			newCampaignCode: 'new password',
 			area: areaId,
 			CampaignId: new Types.ObjectId().toHexString(),
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(401);
 		expect(res.body.OK).toBe(false);
@@ -79,7 +79,7 @@ describe('post on /admin/campaign/changePassword', () => {
 			adminCode,
 			newCampaignCode: '{$ne: null}',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(400);
 		expect(res.body.OK).toBe(false);
@@ -103,7 +103,7 @@ describe('post on /admin/campaign/changePassword', () => {
 			adminCode,
 			newCampaignCode: 'new password2',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.OK).toBe(true);

--- a/tests/admin/campaign/changeName.test.ts
+++ b/tests/admin/campaign/changeName.test.ts
@@ -65,7 +65,7 @@ describe('post on /admin/campaign/changeName', () => {
 			newName: 'newName',
 			area: areaId,
 			CampaignId: new Types.ObjectId(),
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(401);
 		expect(res.body.message).toBe('Wrong campaign id');
@@ -76,7 +76,7 @@ describe('post on /admin/campaign/changeName', () => {
 			adminCode,
 			newName: 'new',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(400);
 		expect(res.body.message).toBe('Name invalid');
@@ -87,7 +87,7 @@ describe('post on /admin/campaign/changeName', () => {
 			adminCode,
 			newName: '{new}',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(400);
 		expect(res.body.message).toBe('Name invalid');
@@ -99,7 +99,7 @@ describe('post on /admin/campaign/changeName', () => {
 				'b109f3bbbc244eb82441917ed06d618b9008dd09b3befd1b5e07394c706a8bb980b1d7785e5976ec049b46df5f1326af5a2ea6d103fd07c95385ffab0cacbc86',
 			newName: 'newName',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.message).toBe('OK');
@@ -112,7 +112,7 @@ describe('post on /admin/campaign/changeName', () => {
 			adminCode,
 			newName: 'newName',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.message).toBe('OK');

--- a/tests/admin/campaign/changeNumberMaxCall.test.ts
+++ b/tests/admin/campaign/changeNumberMaxCall.test.ts
@@ -64,7 +64,7 @@ describe('post on /admin/campaign/changeNumberMaxCall', () => {
 			newNumberMaxCall: 1,
 			area: areaId,
 			CampaignId: new Types.ObjectId(),
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(401);
 		expect(res.body.message).toBe('Wrong campaign id');
@@ -75,7 +75,7 @@ describe('post on /admin/campaign/changeNumberMaxCall', () => {
 			adminCode,
 			newNumberMaxCall: NaN,
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(400);
 		expect(res.body.message).toBe('Missing parameters (newNumberMaxCall:number)');
@@ -86,7 +86,7 @@ describe('post on /admin/campaign/changeNumberMaxCall', () => {
 			adminCode,
 			newNumberMaxCall: 0,
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(400);
 		expect(res.body.message).toBe('invalid number max call');
@@ -108,7 +108,7 @@ describe('post on /admin/campaign/changeNumberMaxCall', () => {
 			adminCode,
 			newNumberMaxCall: 1,
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.message).toBe('OK');

--- a/tests/admin/campaign/changeScript.test.ts
+++ b/tests/admin/campaign/changeScript.test.ts
@@ -63,7 +63,7 @@ describe('post on /admin/campaign/changeScript', () => {
 			adminCode,
 			newScript: 'newScript',
 			area: areaId,
-			allreadyHaseded: true,
+			allreadyHashed: true,
 			CampaignId: new Types.ObjectId()
 		});
 		expect(res.status).toBe(401);
@@ -75,7 +75,7 @@ describe('post on /admin/campaign/changeScript', () => {
 			adminCode,
 			newScript: ' ',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(401);
 		expect(res.body.message).toBe('Wrong script id');
@@ -86,7 +86,7 @@ describe('post on /admin/campaign/changeScript', () => {
 			adminCode: 'password',
 			newScript: 'newScript1',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.message).toBe('OK');
@@ -98,7 +98,7 @@ describe('post on /admin/campaign/changeScript', () => {
 			adminCode,
 			newScript: 'newScript',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.message).toBe('OK');

--- a/tests/admin/campaign/changeTimeBetwenCall.test.ts
+++ b/tests/admin/campaign/changeTimeBetwenCall.test.ts
@@ -64,7 +64,7 @@ describe('post on /admin/campaign/changeTimeBetwenCall', () => {
 			newTimeBetweenCall: 5,
 			area: areaId,
 			CampaignId: new Types.ObjectId(),
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(401);
 		expect(res.body.message).toBe('Wrong campaign id');
@@ -75,7 +75,7 @@ describe('post on /admin/campaign/changeTimeBetwenCall', () => {
 			adminCode,
 			newTimeBetweenCall: 40,
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(400);
 		expect(res.body.message).toBe('Invalid time between call');
@@ -95,7 +95,7 @@ describe('post on /admin/campaign/changeTimeBetwenCall', () => {
 			adminCode,
 			newTimeBetweenCall: 60_000,
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		const newTimeBetweenCall = (await Campaign.findOne({ _id: campaignId }))?.timeBetweenCall;

--- a/tests/admin/campaign/createCampaign.test.ts
+++ b/tests/admin/campaign/createCampaign.test.ts
@@ -40,7 +40,7 @@ describe(' post on /admin/createCampaign', () => {
 			password: 'password',
 			area: areaId,
 			satisfactions: 'satisfaction',
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(400);
 		expect(res.body.message).toBe('Invalid satisfaction, satisfactions must be a array<string>');
@@ -56,7 +56,7 @@ describe(' post on /admin/createCampaign', () => {
 				password: 'password',
 				area: areaId,
 				satisfactions: [1],
-				allreadyHaseded: true
+				allreadyHashed: true
 			});
 		expect(res.status).toBe(400);
 		expect(res.body.message).toBe('Invalid satisfaction, satisfactions must be a array<string>');
@@ -68,7 +68,7 @@ describe(' post on /admin/createCampaign', () => {
 			script: 'createCampaignTest',
 			password: 'password',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(401);
 		expect(res.body.message).toBe('Wrong admin code');
@@ -92,7 +92,7 @@ describe(' post on /admin/createCampaign', () => {
 			script: 'createCampaignTest4',
 			password: 'password',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(400);
 		expect(res.body.message).toBe('Campaign already exist');
@@ -105,7 +105,7 @@ describe(' post on /admin/createCampaign', () => {
 			script: 'createCampaignTest2',
 			password: 'password',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.message).toBe('Campaign created');

--- a/tests/admin/campaign/getCampaign.test.ts
+++ b/tests/admin/campaign/getCampaign.test.ts
@@ -63,7 +63,7 @@ describe(' post on /admin/campaign/getCampaign', () => {
 			adminCode,
 			area: areaId,
 			CampaignId: new Types.ObjectId(),
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(404);
 		expect(res.body.message).toBe('no campaign');
@@ -74,7 +74,7 @@ describe(' post on /admin/campaign/getCampaign', () => {
 			adminCode,
 			area: new Types.ObjectId(),
 			CampaignId: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(401);
 		expect(res.body.message).toBe('Wrong admin code');
@@ -85,7 +85,7 @@ describe(' post on /admin/campaign/getCampaign', () => {
 			adminCode,
 			area: areaId,
 			CampaignId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.message).toBe('OK');
@@ -96,7 +96,7 @@ describe(' post on /admin/campaign/getCampaign', () => {
 		const res = await request(app).post('/admin/campaign/getCampaign').send({
 			adminCode,
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.message).toBe('OK');

--- a/tests/admin/campaign/listCallerCampaign.test.ts
+++ b/tests/admin/campaign/listCallerCampaign.test.ts
@@ -65,7 +65,7 @@ describe(' post on /admin/campaign/listCallerCampaign', () => {
 			adminCode,
 			area: areaId,
 			CampaignId: new Types.ObjectId(),
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(401);
 		expect(res.body.message).toBe('Wrong campaign id');
@@ -76,7 +76,7 @@ describe(' post on /admin/campaign/listCallerCampaign', () => {
 			adminCode,
 			area: areaId,
 			CampaignId: CampaignId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(404);
 		expect(res.body.message).toBe('No callers found');
@@ -108,7 +108,7 @@ describe(' post on /admin/campaign/listCallerCampaign', () => {
 			adminCode,
 			area: areaId,
 			CampaignId: CampaignId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body).toHaveProperty('message', 'OK');

--- a/tests/admin/campaign/listCampaign.test.ts
+++ b/tests/admin/campaign/listCampaign.test.ts
@@ -47,7 +47,7 @@ describe(' post on /admin/campaign/listCampaign', () => {
 		const res = await request(app).post('/admin/campaign/listCampaign').send({
 			adminCode,
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(404);
 		expect(res.body.message).toBe('No campaign found');

--- a/tests/admin/campaign/listClientCampaign.test.ts
+++ b/tests/admin/campaign/listClientCampaign.test.ts
@@ -65,7 +65,7 @@ describe(' post on /admin/campaign/listClientCampaign', () => {
 			adminCode,
 			area: areaId,
 			CampaignId: new Types.ObjectId(),
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(404);
 		expect(res.body.message).toBe('Wrong campaign id');
@@ -76,7 +76,7 @@ describe(' post on /admin/campaign/listClientCampaign', () => {
 			adminCode,
 			area: areaId,
 			CampaignId: CampaignId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(401);
 		expect(res.body.message).toBe('No clients found');
@@ -111,7 +111,7 @@ describe(' post on /admin/campaign/listClientCampaign', () => {
 			adminCode,
 			area: areaId,
 			CampaignId: CampaignId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.data.clients).toBeInstanceOf(Array);

--- a/tests/admin/campaign/setActive.test.ts
+++ b/tests/admin/campaign/setActive.test.ts
@@ -53,7 +53,7 @@ describe('post on /admin/campaign/setActive', () => {
 			adminCode: 'wrong',
 			area: areaId,
 			active: true,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(401);
 		expect(res.body.message).toBe('Wrong admin code');
@@ -65,7 +65,7 @@ describe('post on /admin/campaign/setActive', () => {
 			area: areaId,
 			active: true,
 			campaign: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(404);
 		expect(res.body.message).toBe('Campaign not found');
@@ -77,7 +77,7 @@ describe('post on /admin/campaign/setActive', () => {
 			area: areaId,
 			active: true,
 			campaign: CampaignId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.message).toBe('Campaign activated');
@@ -91,7 +91,7 @@ describe('post on /admin/campaign/setActive', () => {
 			area: areaId,
 			active: false,
 			campaign: CampaignId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.message).toBe('Campaign desactivated');

--- a/tests/admin/campaign/setPriority.test.ts
+++ b/tests/admin/campaign/setPriority.test.ts
@@ -57,7 +57,7 @@ describe('post on /admin/campaign/setPriority', () => {
 		const res = await request(app).post('/admin/campaign/setPriority').send({
 			adminCode,
 			area: areaId,
-			allreadyHaseded: true,
+			allreadyHashed: true,
 			priority: 'notAnArray'
 		});
 		expect(res.status).toBe(400);
@@ -71,7 +71,7 @@ describe('post on /admin/campaign/setPriority', () => {
 			.send({
 				adminCode: 'wrong',
 				area: areaId,
-				allreadyHaseded: true,
+				allreadyHashed: true,
 				priority: [
 					{ name: 'prio2', id: 'md4ryvjl' },
 					{ name: 'prio1', id: 'md4rye5b' }
@@ -88,7 +88,7 @@ describe('post on /admin/campaign/setPriority', () => {
 				adminCode,
 				area: areaId,
 				CampaignId: new Types.ObjectId().toHexString(),
-				allreadyHaseded: true,
+				allreadyHashed: true,
 				priority: [
 					{ name: 'prio2', id: 'md4ryvjl' },
 					{ name: 'prio1', id: 'md4rye5b' }
@@ -104,7 +104,7 @@ describe('post on /admin/campaign/setPriority', () => {
 			.send({
 				adminCode,
 				area: areaId,
-				allreadyHaseded: true,
+				allreadyHashed: true,
 				priority: [42]
 			});
 		expect(res.status).toBe(400);
@@ -119,7 +119,7 @@ describe('post on /admin/campaign/setPriority', () => {
 			.send({
 				adminCode,
 				area: areaId,
-				allreadyHaseded: true,
+				allreadyHashed: true,
 				priority: [
 					{ name: 'prio2', id: 'md4ryvjl' },
 					{ name: 'prio1', id: 'md4rye5b' }

--- a/tests/admin/campaign/setSatisfaction.test.ts
+++ b/tests/admin/campaign/setSatisfaction.test.ts
@@ -90,7 +90,22 @@ describe('post on /admin/campaign/setSatisfaction', () => {
 			});
 		expect(res.status).toBe(400);
 		expect(res.body.message).toBe(
-			'Invalid satisfaction, satisfactions must be a array<{ name: String, toRecall: Boolean }>'
+			'Invalid satisfaction, satisfactions must be a array<{ name: String, toRecall: Boolean }> name dont contain "[hide] validate by API"'
+		);
+	});
+
+	it('should return 400 if satisfactions is "[hide] validate by API"', async () => {
+		const res = await request(app)
+			.post('/admin/campaign/setSatisfaction')
+			.send({
+				adminCode,
+				area: areaId,
+				allreadyHaseded: true,
+				satisfactions: [{ name: '[hide] validate by API', toRecall: false }]
+			});
+		expect(res.status).toBe(400);
+		expect(res.body.message).toBe(
+			'Invalid satisfaction, satisfactions must be a array<{ name: String, toRecall: Boolean }> name dont contain "[hide] validate by API"'
 		);
 	});
 
@@ -110,7 +125,8 @@ describe('post on /admin/campaign/setSatisfaction', () => {
 		const campaign = await Campaign.findOne({ _id: CampaignId });
 		expect(campaign?.status).toMatchObject([
 			{ name: 'satisfaction1', toRecall: true },
-			{ name: 'satisfaction2', toRecall: true }
+			{ name: 'satisfaction2', toRecall: true },
+			{ name: '[hide] validate by API', toRecall: false }
 		]);
 	});
 });

--- a/tests/admin/campaign/setSatisfaction.test.ts
+++ b/tests/admin/campaign/setSatisfaction.test.ts
@@ -52,7 +52,7 @@ describe('post on /admin/campaign/setSatisfaction', () => {
 		const res = await request(app).post('/admin/campaign/setSatisfaction').send({
 			adminCode,
 			area: areaId,
-			allreadyHaseded: true,
+			allreadyHashed: true,
 			satisfactions: 'notAnArray'
 		});
 		expect(res.status).toBe(400);
@@ -62,7 +62,7 @@ describe('post on /admin/campaign/setSatisfaction', () => {
 		const res = await request(app).post('/admin/campaign/setSatisfaction').send({
 			adminCode: 'wrong',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(401);
 		expect(res.body.message).toBe('Wrong admin code');
@@ -73,7 +73,7 @@ describe('post on /admin/campaign/setSatisfaction', () => {
 			adminCode,
 			area: areaId,
 			CampaignId: new Types.ObjectId().toHexString(),
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(401);
 		expect(res.body.message).toBe('Wrong campaign id');
@@ -85,7 +85,7 @@ describe('post on /admin/campaign/setSatisfaction', () => {
 			.send({
 				adminCode,
 				area: areaId,
-				allreadyHaseded: true,
+				allreadyHashed: true,
 				satisfactions: [42]
 			});
 		expect(res.status).toBe(400);
@@ -100,7 +100,7 @@ describe('post on /admin/campaign/setSatisfaction', () => {
 			.send({
 				adminCode,
 				area: areaId,
-				allreadyHaseded: true,
+				allreadyHashed: true,
 				satisfactions: [{ name: '[hide] validate by API', toRecall: false }]
 			});
 		expect(res.status).toBe(400);
@@ -115,7 +115,7 @@ describe('post on /admin/campaign/setSatisfaction', () => {
 			.send({
 				adminCode,
 				area: areaId,
-				allreadyHaseded: true,
+				allreadyHashed: true,
 				satisfactions: [
 					{ name: 'satisfaction1', toRecall: true },
 					{ name: 'satisfaction2', toRecall: true }

--- a/tests/admin/client/clientInfo.test.ts
+++ b/tests/admin/client/clientInfo.test.ts
@@ -101,7 +101,7 @@ describe('post on /admin/client/clientInfo', () => {
 			adminCode: adminPassword,
 			area: areaId,
 			campaign: new mongoose.Types.ObjectId(),
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(404);
 		expect(res.body.message).toBe('Campaign not found');
@@ -112,7 +112,7 @@ describe('post on /admin/client/clientInfo', () => {
 			adminCode: adminPassword,
 			area: areaId,
 			campaign: campaignId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(404);
 		expect(res.body.message).toBe('Client not found');
@@ -123,7 +123,7 @@ describe('post on /admin/client/clientInfo', () => {
 			adminCode: adminPassword,
 			area: areaId,
 			campaign: campaignId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.message).toBe('no call found for this client');
@@ -152,7 +152,7 @@ describe('post on /admin/client/clientInfo', () => {
 			adminCode: adminPassword,
 			area: areaId,
 			campaign: campaignId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.OK).toBe(true);

--- a/tests/admin/client/createClient.test.ts
+++ b/tests/admin/client/createClient.test.ts
@@ -92,7 +92,7 @@ describe('post on /admin/client/createClient', () => {
 			name: 'createClienttest',
 			adminCode: adminPassword,
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(400);
 		expect(res.body.message).toBe('Wrong phone number');
@@ -104,7 +104,7 @@ describe('post on /admin/client/createClient', () => {
 			name: 'createClienttest',
 			adminCode: adminPassword,
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(422);
 		expect(res.body.message).toBe('User already exist');
@@ -118,7 +118,7 @@ describe('post on /admin/client/createClient', () => {
 			firstName: 'createClienttest',
 			institution: 'createClienttest',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		const client = await Client.findOne({ phone: '+33134567891' });
@@ -135,7 +135,7 @@ describe('post on /admin/client/createClient', () => {
 				firstName: 'createClienttest2',
 				institution: 'createClienttest2',
 				area: areaId,
-				allreadyHaseded: true,
+				allreadyHashed: true,
 				priority: [{ campaign: campaignId, id: 'md4rye5b' }]
 			});
 		expect(res.status).toBe(200);
@@ -151,7 +151,7 @@ describe('post on /admin/client/createClient', () => {
 			firstName: 'createClienttestUpdated',
 			institution: 'createClienttestUpdated',
 			area: areaId,
-			allreadyHaseded: true,
+			allreadyHashed: true,
 			updateKey: clientId,
 			updateIfExist: true
 		});
@@ -170,7 +170,7 @@ describe('post on /admin/client/createClient', () => {
 			firstName: 'createClienttestUpdated',
 			institution: 'createClienttestUpdated',
 			area: areaId,
-			allreadyHaseded: true,
+			allreadyHashed: true,
 			updateKey: clientId,
 			updateIfExist: true
 		});

--- a/tests/admin/client/exportClientsCsv.test.ts
+++ b/tests/admin/client/exportClientsCsv.test.ts
@@ -63,7 +63,7 @@ describe('post on /admin/client/exportClientsCsv', () => {
 			adminCode,
 			area: areaId,
 			CampaignId: new Types.ObjectId(),
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toEqual(401);
 		expect(res.body).toEqual({ message: 'Wrong campaign id', OK: false });
@@ -73,7 +73,7 @@ describe('post on /admin/client/exportClientsCsv', () => {
 		const res = await request(app).post('/admin/client/exportClientsCsv').send({
 			adminCode,
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toEqual(200);
 	});

--- a/tests/admin/client/removeAllClient.test.ts
+++ b/tests/admin/client/removeAllClient.test.ts
@@ -73,7 +73,7 @@ describe('post on /admin/client/removeClients', () => {
 			adminCode,
 			area: areaId,
 			CampaignId: new Types.ObjectId(),
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toEqual(401);
 		expect(res.body).toEqual({ message: 'Wrong campaign id', OK: false });
@@ -84,7 +84,7 @@ describe('post on /admin/client/removeClients', () => {
 			adminCode,
 			area: areaId,
 			CampaignId: campaignId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toEqual(200);
 		expect(res.body).toEqual({ message: 'OK', OK: true });

--- a/tests/admin/client/removeClient.test.ts
+++ b/tests/admin/client/removeClient.test.ts
@@ -74,7 +74,7 @@ describe('post on /admin/client/removeClient', () => {
 			adminCode,
 			area: areaId,
 			phone: 'wrongPhone',
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(400);
 		expect(res.body.OK).toBe(false);
@@ -85,7 +85,7 @@ describe('post on /admin/client/removeClient', () => {
 			adminCode,
 			area: new Types.ObjectId(),
 			phone: '+33134567890',
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(401);
 		expect(res.body.OK).toBe(false);
@@ -97,7 +97,7 @@ describe('post on /admin/client/removeClient', () => {
 			area: areaId,
 			phone: '+33134567890',
 			CampaignId: new Types.ObjectId(),
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(401);
 		expect(res.body.OK).toBe(false);
@@ -108,7 +108,7 @@ describe('post on /admin/client/removeClient', () => {
 			adminCode,
 			area: areaId,
 			phone: '+33134567891',
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(404);
 		expect(res.body.OK).toBe(false);
@@ -119,7 +119,7 @@ describe('post on /admin/client/removeClient', () => {
 			adminCode,
 			area: areaId,
 			phone: '+33134567890',
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.OK).toBe(true);
@@ -148,7 +148,7 @@ describe('post on /admin/client/removeClient', () => {
 			adminCode,
 			area: areaId,
 			phone: '+33134567892',
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.OK).toBe(true);

--- a/tests/admin/client/searchComplete.test.ts
+++ b/tests/admin/client/searchComplete.test.ts
@@ -82,7 +82,7 @@ describe('post on /admin/client/searchComplete', () => {
 	it('should works', async () => {
 		const res = await request(app).post('/admin/client/searchComplete').send({
 			adminCode,
-			allreadyHaseded: true,
+			allreadyHashed: true,
 			name: 'ZRAIKA',
 			firstName: 'Romane',
 			area: areaId
@@ -99,7 +99,7 @@ describe('post on /admin/client/searchComplete', () => {
 	it('should works with phoneStart', async () => {
 		const res = await request(app).post('/admin/client/searchComplete').send({
 			adminCode,
-			allreadyHaseded: true,
+			allreadyHashed: true,
 			name: 'ZRAIKA',
 			firstName: 'Romane',
 			phoneStart: '+3313',
@@ -117,7 +117,7 @@ describe('post on /admin/client/searchComplete', () => {
 	it('should works with phoneEnd', async () => {
 		const res = await request(app).post('/admin/client/searchComplete').send({
 			adminCode,
-			allreadyHaseded: true,
+			allreadyHashed: true,
 			name: 'ZRAIKA',
 			firstName: 'Romane',
 			phoneEnd: '90',
@@ -135,7 +135,7 @@ describe('post on /admin/client/searchComplete', () => {
 	it('should works with phoneStart and phoneEnd', async () => {
 		const res = await request(app).post('/admin/client/searchComplete').send({
 			adminCode,
-			allreadyHaseded: true,
+			allreadyHashed: true,
 			name: 'ZRAIKA',
 			firstName: 'Romane',
 			phoneStart: '+3313',
@@ -154,7 +154,7 @@ describe('post on /admin/client/searchComplete', () => {
 	it('should works with invalid case', async () => {
 		const res = await request(app).post('/admin/client/searchComplete').send({
 			adminCode,
-			allreadyHaseded: true,
+			allreadyHashed: true,
 			name: 'ZrAiKa',
 			firstName: 'rOmAnE',
 			area: areaId
@@ -171,7 +171,7 @@ describe('post on /admin/client/searchComplete', () => {
 	it('should works with invalid case and phone', async () => {
 		const res = await request(app).post('/admin/client/searchComplete').send({
 			adminCode,
-			allreadyHaseded: true,
+			allreadyHashed: true,
 			name: 'ZrAiKa',
 			firstName: 'rOmAnE',
 			phoneStart: '+3313',
@@ -190,7 +190,7 @@ describe('post on /admin/client/searchComplete', () => {
 	it('should works with phoneStart and phoneEnd second pass', async () => {
 		const res = await request(app).post('/admin/client/searchComplete').send({
 			adminCode,
-			allreadyHaseded: true,
+			allreadyHashed: true,
 			name: 'ZAIKA',
 			firstName: 'Romane',
 			phoneStart: '+3313',
@@ -209,7 +209,7 @@ describe('post on /admin/client/searchComplete', () => {
 	it('should works with second pass', async () => {
 		const res = await request(app).post('/admin/client/searchComplete').send({
 			adminCode,
-			allreadyHaseded: true,
+			allreadyHashed: true,
 			name: 'ZAIKA',
 			firstName: 'Romane',
 			area: areaId
@@ -226,7 +226,7 @@ describe('post on /admin/client/searchComplete', () => {
 	it('should works with invalid case second pass', async () => {
 		const res = await request(app).post('/admin/client/searchComplete').send({
 			adminCode,
-			allreadyHaseded: true,
+			allreadyHashed: true,
 			name: 'ZAiKa',
 			firstName: 'rOmAnE',
 			area: areaId
@@ -243,7 +243,7 @@ describe('post on /admin/client/searchComplete', () => {
 	it('should return 404 if no client found', async () => {
 		const res = await request(app).post('/admin/client/searchComplete').send({
 			adminCode,
-			allreadyHaseded: true,
+			allreadyHashed: true,
 			name: 'searchCompleteTest',
 			firstName: 'searchCompleteTest',
 			area: areaId

--- a/tests/admin/client/shearchByName.test.ts
+++ b/tests/admin/client/shearchByName.test.ts
@@ -80,7 +80,7 @@ describe('post on /admin/client/searchByName', () => {
 			adminCode: adminCode,
 			name: 'searchByNameTest',
 			area: areaId,
-			allreadyHaseded: true
+			allreadyHashed: true
 		});
 		expect(res.status).toBe(200);
 		expect(res.body.OK).toBe(true);

--- a/tests/admin/client/validateByAPI.test.ts
+++ b/tests/admin/client/validateByAPI.test.ts
@@ -1,0 +1,138 @@
+import dotenv from 'dotenv';
+import mongoose from 'mongoose';
+import request from 'supertest';
+import app from '../../../index';
+import { Area } from '../../../Models/Area';
+import { Campaign } from '../../../Models/Campaign';
+import { Client } from '../../../Models/Client';
+import { Caller } from '../../../Models/Caller';
+import { Call } from '../../../Models/Call';
+import call from 'router/admin/stats/call';
+
+dotenv.config({ path: '.env' });
+
+let areaId: mongoose.Types.ObjectId | undefined;
+let campaignId: mongoose.Types.ObjectId | undefined;
+let clientId: mongoose.Types.ObjectId | undefined;
+const adminCode =
+	'b109f3bbbc244eb82441917ed06d618b9008dd09b3befd1b5e07394c706a8bb980b1d7785e5976ec049b46df5f1326af5a2ea6d103fd07c95385ffab0cacbc86'; //password
+
+beforeAll(async () => {
+	await mongoose.connect(process.env.URITEST ?? '');
+	await Area.deleteMany({});
+	await Client.deleteMany({});
+	await Caller.deleteMany({});
+	await Call.deleteMany({});
+
+	areaId = (
+		await Area.create({
+			name: 'validateByAPITest',
+			password: 'password',
+			campaignList: [],
+			adminPassword: adminCode
+		})
+	).id;
+
+	campaignId = (
+		await Campaign.create({
+			name: 'validateByAPITest',
+			script: 'validateByAPITest',
+			active: true,
+			area: areaId,
+			status: [
+				{ name: 'À rappeler', toRecall: true },
+				{ name: 'À retirer', toRecall: false },
+				{ name: '[hide] validate by API', toRecall: false }
+			],
+			password: 'password'
+		})
+	).id;
+
+	clientId = (
+		await Client.create({
+			name: 'ZRAIKA',
+			firstname: 'Romane',
+			phone: '+33134567890',
+			area: areaId,
+			campaigns: [campaignId],
+			priority: [{ campaign: campaignId, id: '-1' }]
+		})
+	).id;
+	await Client.create({
+		name: 'other',
+		phone: '+33134567891',
+		area: areaId,
+		campaigns: [campaignId],
+		priority: [{ campaign: campaignId, id: '-1' }]
+	});
+	Area.updateOne({ _id: areaId }, { $push: { campaignList: campaignId } });
+});
+
+afterAll(async () => {
+	await mongoose.connection.close();
+});
+
+describe('post on /admin/client/validateByAPI', () => {
+	it('should return 401 if wrong admin code', async () => {
+		const res = await request(app).post('/admin/client/validateByAPI').send({
+			adminCode: 'wrongPassword',
+			name: 'validateByAPITest',
+			firstName: 'validateByAPITest',
+			comment: 'auto-validate by test suite',
+			area: areaId
+		});
+		expect(res.status).toBe(401);
+		expect(res.body.OK).toBe(false);
+		expect(res.body.message).toBe('Wrong admin code');
+	});
+
+	it('should works', async () => {
+		const res = await request(app).post('/admin/client/validateByAPI').send({
+			adminCode,
+			allreadyHaseded: true,
+			name: 'ZRAIKA',
+			firstName: 'Romane',
+			comment: 'auto-validate by test suite1',
+			area: areaId
+		});
+		expect(res.status).toBe(200);
+		expect(res.body.OK).toBe(true);
+		expect(res.body.message).toBe('this client has been validate');
+		const call = await Call.findOne({ comment: 'auto-validate by test suite1' });
+		expect(call).toMatchObject({
+			satisfaction: '[hide] validate by API',
+			comment: 'auto-validate by test suite1',
+			status: false,
+			duration: 0
+		});
+	});
+
+	it('should works with Caller already exist', async () => {
+		await Caller.deleteMany({});
+		await new Caller({
+			name: 'API Caller',
+			phone: '+33000000000',
+			pinCode: '1970',
+			campaigns: await Campaign.find({}, [])
+		}).save();
+
+		const res = await request(app).post('/admin/client/validateByAPI').send({
+			adminCode,
+			allreadyHaseded: true,
+			name: 'ZRAIKA',
+			firstName: 'Romane',
+			comment: 'auto-validate by test suite2',
+			area: areaId
+		});
+		expect(res.status).toBe(200);
+		expect(res.body.OK).toBe(true);
+		expect(res.body.message).toBe('this client has been validate');
+		const call = await Call.findOne({ comment: 'auto-validate by test suite2' });
+		expect(call).toMatchObject({
+			satisfaction: '[hide] validate by API',
+			comment: 'auto-validate by test suite2',
+			status: false,
+			duration: 0
+		});
+	});
+});

--- a/tests/admin/client/validateByAPI.test.ts
+++ b/tests/admin/client/validateByAPI.test.ts
@@ -3,12 +3,10 @@ import mongoose from 'mongoose';
 import request from 'supertest';
 import app from '../../../index';
 import { Area } from '../../../Models/Area';
+import { Call } from '../../../Models/Call';
+import { Caller } from '../../../Models/Caller';
 import { Campaign } from '../../../Models/Campaign';
 import { Client } from '../../../Models/Client';
-import { Caller } from '../../../Models/Caller';
-import { Call } from '../../../Models/Call';
-import call from 'router/admin/stats/call';
-
 dotenv.config({ path: '.env' });
 
 let areaId: mongoose.Types.ObjectId | undefined;
@@ -124,15 +122,9 @@ describe('post on /admin/client/validateByAPI', () => {
 			comment: 'auto-validate by test suite2',
 			area: areaId
 		});
+
 		expect(res.status).toBe(200);
 		expect(res.body.OK).toBe(true);
-		expect(res.body.message).toBe('this client has been validate');
-		const call = await Call.findOne({ comment: 'auto-validate by test suite2' });
-		expect(call).toMatchObject({
-			satisfaction: '[hide] validate by API',
-			comment: 'auto-validate by test suite2',
-			status: false,
-			duration: 0
-		});
+		expect(res.body.message).toBe('this client is already called by an reel caller');
 	});
 });

--- a/tests/admin/client/validateByAPI.test.ts
+++ b/tests/admin/client/validateByAPI.test.ts
@@ -89,7 +89,7 @@ describe('post on /admin/client/validateByAPI', () => {
 	it('should works', async () => {
 		const res = await request(app).post('/admin/client/validateByAPI').send({
 			adminCode,
-			allreadyHaseded: true,
+			allreadyHashed: true,
 			name: 'ZRAIKA',
 			firstName: 'Romane',
 			comment: 'auto-validate by test suite1',

--- a/tests/admin/client/validateByAPI.test.ts
+++ b/tests/admin/client/validateByAPI.test.ts
@@ -17,6 +17,7 @@ const adminCode =
 
 beforeAll(async () => {
 	await mongoose.connect(process.env.URITEST ?? '');
+
 	await Area.deleteMany({});
 	await Client.deleteMany({});
 	await Caller.deleteMany({});
@@ -56,6 +57,7 @@ beforeAll(async () => {
 			priority: [{ campaign: campaignId, id: '-1' }]
 		})
 	).id;
+
 	await Client.create({
 		name: 'other',
 		phone: '+33134567891',
@@ -63,7 +65,7 @@ beforeAll(async () => {
 		campaigns: [campaignId],
 		priority: [{ campaign: campaignId, id: '-1' }]
 	});
-	Area.updateOne({ _id: areaId }, { $push: { campaignList: campaignId } });
+	await Area.updateOne({ _id: areaId }, { $push: { campaignList: campaignId } });
 });
 
 afterAll(async () => {
@@ -103,28 +105,5 @@ describe('post on /admin/client/validateByAPI', () => {
 			status: false,
 			duration: 0
 		});
-	});
-
-	it('should works with Caller already exist', async () => {
-		await Caller.deleteMany({});
-		await new Caller({
-			name: 'API Caller',
-			phone: '+33000000000',
-			pinCode: '1970',
-			campaigns: await Campaign.find({}, [])
-		}).save();
-
-		const res = await request(app).post('/admin/client/validateByAPI').send({
-			adminCode,
-			allreadyHaseded: true,
-			name: 'ZRAIKA',
-			firstName: 'Romane',
-			comment: 'auto-validate by test suite2',
-			area: areaId
-		});
-
-		expect(res.status).toBe(200);
-		expect(res.body.OK).toBe(true);
-		expect(res.body.message).toBe('this client is already called by an reel caller');
 	});
 });

--- a/tests/admin/login.test.ts
+++ b/tests/admin/login.test.ts
@@ -80,7 +80,8 @@ describe('post on /admin/login', () => {
 				actualCampaignCallPermited: true,
 				actualCampaignStatus: [
 					{ name: 'À rappeler', toRecall: true },
-					{ name: 'À retirer', toRecall: false }
+					{ name: 'À retirer', toRecall: false },
+					{ name: '[hide] validate by API', toRecall: false }
 				]
 			},
 			OK: true
@@ -105,7 +106,8 @@ describe('post on /admin/login', () => {
 				actualCampaignCallPermited: true,
 				actualCampaignStatus: [
 					{ name: 'À rappeler', toRecall: true },
-					{ name: 'À retirer', toRecall: false }
+					{ name: 'À retirer', toRecall: false },
+					{ name: '[hide] validate by API', toRecall: false }
 				]
 			},
 			OK: true

--- a/tests/admin/login.test.ts
+++ b/tests/admin/login.test.ts
@@ -92,7 +92,7 @@ describe('post on /admin/login', () => {
 	it('should return 200 if correct admin code with hash', async () => {
 		const res = await request(app)
 			.post('/admin/login')
-			.send({ adminCode: adminPassword, area: areaId, allreadyHaseded: true });
+			.send({ adminCode: adminPassword, area: areaId, allreadyHashed: true });
 		expect(res.status).toBe(200);
 		expect(res.body).toMatchObject({
 			message: 'OK',

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -1,6 +1,11 @@
 import { Response } from 'express';
 import { sha512 } from 'js-sha512';
 import mongoose from 'mongoose';
+import stringSimilarity from 'string-similarity';
+
+import { Caller } from '../Models/Caller';
+import { Campaign } from '../Models/Campaign';
+import { Client } from '../Models/Client';
 import { log } from './log';
 
 /**
@@ -248,14 +253,116 @@ function hashPasword(password: string, allreadyHaseded: boolean, res: Response<a
 	return password;
 }
 
+async function partialShearchClient(
+	campaign: InstanceType<typeof Campaign> | null,
+	name: string,
+	firstName: string,
+	phoneFragmentStart?: string,
+	phoneFragmentEnd?: string
+): Promise<{
+	message: string;
+	OK: boolean;
+	data?: { [key: string]: any };
+}> {
+	const searchName = name?.trim();
+	const searchFirstName = firstName?.trim();
+	let phoneStart = phoneFragmentStart?.trim();
+	let phoneEnd = phoneFragmentEnd?.trim();
+
+	const query: any = { campaigns: campaign };
+
+	function escapeRegex(value: string): string {
+		return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	}
+
+	phoneStart = phoneStart ? escapeRegex(phoneStart) : '';
+	phoneEnd = phoneEnd ? escapeRegex(phoneEnd) : '';
+
+	if (phoneStart && phoneEnd) {
+		query.phone = { $regex: new RegExp(`^\\+?${phoneStart}\\d*${phoneEnd}$`, 'i') };
+	} else if (phoneStart) {
+		query.phone = { $regex: new RegExp(`^\\+?${phoneStart}\\d*`, 'i') };
+	} else if (phoneEnd) {
+		query.phone = { $regex: new RegExp(`+\\d*${phoneEnd}$`, 'i') };
+	}
+
+	const fistPassQuery = { ...query };
+	if (searchName) {
+		fistPassQuery.name = { $regex: new RegExp(`^${searchName}$`, 'i') };
+	}
+	if (searchFirstName) {
+		fistPassQuery.firstname = { $regex: new RegExp(`^${searchFirstName}$`, 'i') };
+	}
+
+	const clients = await Client.find(fistPassQuery, ['name', 'phone', 'firstname']).limit(1);
+
+	if (!clients || clients.length != 1) {
+		return await searchWithCursor();
+	} else {
+		return { message: 'found on first pass', OK: true, data: clients[0] };
+	}
+	// =========== deep search =========== \\
+	async function searchWithCursor() {
+		const cursor = Client.find(query, ['name', 'firstname', 'phone']).cursor();
+
+		let bestMatch: any = null;
+		let bestScore = 0;
+
+		for await (const client of cursor) {
+			let score = 0;
+			if (searchName && client.name) {
+				score += stringSimilarity.compareTwoStrings(searchName.toLowerCase(), client.name.toLowerCase());
+			}
+			if (searchFirstName && client.firstname) {
+				score += stringSimilarity.compareTwoStrings(
+					searchFirstName.toLowerCase(),
+					client.firstname.toLowerCase()
+				);
+			}
+
+			if (score > bestScore) {
+				bestScore = score;
+				bestMatch = client;
+			}
+
+			if (score >= 1.8) break;
+		}
+
+		if (bestMatch && bestScore >= 0.5) {
+			return { message: 'found on second pass', OK: true, data: bestMatch };
+		} else {
+			return { message: 'no client found', OK: false };
+		}
+	}
+}
+
+async function getApiCaller() {
+	let caller: InstanceType<typeof Caller> | null = await Caller.findOne({
+		name: 'API Caller',
+		phone: '+33000000000',
+		pinCode: '1970'
+	});
+	if (!caller) {
+		caller = await new Caller({
+			name: 'API Caller',
+			phone: '+33000000000',
+			pinCode: '1970',
+			campaigns: await Campaign.find({}, [])
+		}).save();
+	}
+
+	return caller;
+}
 export {
 	checkParameters,
 	checkPinCode,
 	cleanStatus,
 	clearPhone,
+	getApiCaller,
 	getFileName,
 	hashPasword,
 	humainPhone,
+	partialShearchClient,
 	phoneNumberCheck,
 	sanitizeString
 };

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -253,7 +253,7 @@ function hashPasword(password: string, allreadyHaseded: boolean, res: Response<a
 	return password;
 }
 
-async function partialShearchClient(
+async function partialSearchClient(
 	campaign: InstanceType<typeof Campaign> | null,
 	name: string,
 	firstName: string,
@@ -362,7 +362,7 @@ export {
 	getFileName,
 	hashPasword,
 	humainPhone,
-	partialShearchClient,
+	partialSearchClient,
 	phoneNumberCheck,
 	sanitizeString
 };

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -336,29 +336,11 @@ async function partialSearchClient(
 	}
 }
 
-async function getApiCaller() {
-	let caller: InstanceType<typeof Caller> | null = await Caller.findOne({
-		name: 'API Caller',
-		phone: '+33000000000',
-		pinCode: '1970'
-	});
-	if (!caller) {
-		caller = await new Caller({
-			name: 'API Caller',
-			phone: '+33000000000',
-			pinCode: '1970',
-			campaigns: await Campaign.find({}, [])
-		}).save();
-	}
-
-	return caller;
-}
 export {
 	checkParameters,
 	checkPinCode,
 	cleanStatus,
 	clearPhone,
-	getApiCaller,
 	getFileName,
 	hashPasword,
 	humainPhone,

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -238,8 +238,8 @@ function checkPinCode(pinCode: string, res: Response<any>, orgin: string): boole
 	return true;
 }
 
-function hashPasword(password: string, allreadyHaseded: boolean, res: Response<any>): string | false {
-	if (!allreadyHaseded || password.length !== 128) {
+function hashPasword(password: string, allreadyHashed: boolean, res: Response<any>): string | false {
+	if (!allreadyHashed || password.length !== 128) {
 		return sha512(password).toString();
 	}
 
@@ -286,15 +286,15 @@ async function partialSearchClient(
 		query.phone = { $regex: new RegExp(`+\\d*${phoneEnd}$`, 'i') };
 	}
 
-	const fistPassQuery = { ...query };
+	const firstPassQuery = { ...query };
 	if (searchName) {
-		fistPassQuery.name = { $regex: new RegExp(`^${searchName}$`, 'i') };
+		firstPassQuery.name = { $regex: new RegExp(`^${searchName}$`, 'i') };
 	}
 	if (searchFirstName) {
-		fistPassQuery.firstname = { $regex: new RegExp(`^${searchFirstName}$`, 'i') };
+		firstPassQuery.firstname = { $regex: new RegExp(`^${searchFirstName}$`, 'i') };
 	}
 
-	const clients = await Client.find(fistPassQuery, ['name', 'phone', 'firstname']).limit(1);
+	const clients = await Client.find(firstPassQuery, ['name', 'phone', 'firstname']).limit(1);
 
 	if (!clients || clients.length != 1) {
 		return await searchWithCursor();

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -264,10 +264,10 @@ async function partialSearchClient(
 	OK: boolean;
 	data?: { [key: string]: any };
 }> {
-	const searchName = name?.trim();
-	const searchFirstName = firstName?.trim();
-	let phoneStart = phoneFragmentStart?.trim();
-	let phoneEnd = phoneFragmentEnd?.trim();
+	const searchName = sanitizeString(name?.trim());
+	const searchFirstName = sanitizeString(firstName?.trim());
+	let phoneStart = sanitizeString(phoneFragmentStart?.trim() ?? '');
+	let phoneEnd = sanitizeString(phoneFragmentEnd?.trim() ?? '');
 
 	const query: any = { campaigns: campaign };
 


### PR DESCRIPTION
## Pull Request Overview

This PR adds API-based client validation functionality that allows external systems to validate clients without making actual phone calls. The implementation introduces a new endpoint for programmatic client validation and automatically adds a hidden status "[hide] validate by API" to campaign satisfaction options.

- Adds new `/admin/client/validateByAPI` endpoint for external validation
- Implements partial client search functionality with fuzzy string matching
- Introduces hidden "[hide] validate by API" status that is excluded from statistical reports

### Reviewed Changes

Copilot reviewed 13 out of 13 changed files in this pull request and generated 11 comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| `tools/utils.ts` | Adds `partialSearchClient` function for fuzzy client matching with phone number fragments |
| `router/admin/client/validateByAPI.ts` | New endpoint implementing API-based client validation workflow |
| `router/admin/client/searchComplete.ts` | Refactored to use shared `partialSearchClient` utility function |
| `router/admin/campaign/setSatisfaction.ts` | Automatically adds hidden validation status and prevents manual inclusion |
| `router/admin/stats/` | Updated statistics endpoints to filter out hidden validation entries |
| `Models/Campaign.ts` | Adds default "[hide] validate by API" status to campaign schema |
| Test files | Added comprehensive test coverage for new validation functionality |
| `routes.ts` | Registers new validation endpoint |
</details>
